### PR TITLE
Hold the picture at the start angle, refine the fold look, and add an English/Chinese UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,21 @@ build/
 .DS_Store
 *.air
 *.metallib
+
+# Local build products and diagnostics
+work/
+*.app/
+*.saver/
+*.dmg
+*.dSYM/
+*.log
+
+# Local credentials and developer configuration
+.env
+.env.*
+!.env.example
+*.p12
+*.pfx
+*.mobileprovision
+*.provisionprofile
+build.local.sh

--- a/Info.plist
+++ b/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>zh_CN</string>
+	<string>en</string>
 	<key>CFBundleDisplayName</key>
 	<string>macTilt</string>
 	<key>CFBundleExecutable</key>
@@ -16,6 +16,7 @@
 	<string>6.0</string>
 	<key>CFBundleLocalizations</key>
 	<array>
+		<string>en</string>
 		<string>zh-Hans</string>
 	</array>
 	<key>CFBundleName</key>

--- a/Info.plist
+++ b/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>zh_CN</string>
 	<key>CFBundleDisplayName</key>
 	<string>macTilt</string>
 	<key>CFBundleExecutable</key>
@@ -14,6 +14,10 @@
 	<string>com.lqsky7.mactilt</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>zh-Hans</string>
+	</array>
 	<key>CFBundleName</key>
 	<string>macTilt</string>
 	<key>CFBundlePackageType</key>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The **macTilt** 3D clamshell fold animation for MacBooks driven by the physical 
 Rather than rendering inside a separate window, **the entire macOS display follows the animation in 3D space as you close your MacBook lid**.
 
 ## NOTE
-- **Opening MacBook**: it's not possible to do it on lock screen due to macOS restrictions (without disabling SIP, which i don’t recommend). Because in that case any malicious app would be able to draw a login flow on your lock screen and steal your passwords. But i have implemented the animation for opening when screen is unlocked
+- **锁屏开盖动画（本地增强版）**：通过 SkyLight 私有显示空间呈现壁纸展开动画。唤醒时补充 0.8 秒展开过渡；锁定期间以 60 Hz 持续读取开合角度，反复合盖、开盖均可触发，没有动画截止时间。系统真正睡眠时进程暂停，唤醒后恢复。接口可能随系统更新变化；不适用于重启后的 FileVault 预启动解锁界面。
 - **Normal MacBook Use**: When you are actively using your MacBook (lid is open), the app does **nothing** (overlay is completely hidden, zero CPU/GPU overhead, full click-through).
 - **Closing MacBook**: As you tilt the screen closed, the display freezes the screen and seamlessly folds **from up to down** toward the bottom keyboard hinge into the dark void.
 ---
@@ -29,7 +29,7 @@ Rather than rendering inside a separate window, **the entire macOS display follo
   - **Image Source**: Live Screen Capture (`ScreenCaptureKit`), Desktop Wallpaper, Bundled Artwork, or Custom Photo.
   - **Test Preview Slider**: Scrub and preview the up-to-down closing fold interactively without moving your MacBook lid.
 - 🍸 **Menu Bar Extra**: Quick angle readout (e.g. `126°`), status monitoring, and settings shortcuts.
-- 🚀 **Automated Build & Install (`build.sh`)**: Increments the version number and build number automatically on each run and installs the `.app` directly to `/Applications`.
+- 🚀 **Automated Build & Install (`build.sh`)**: Builds without modifying source version metadata and installs the `.app` directly to `/Applications`.
 
 ---
 
@@ -48,12 +48,21 @@ Run the automated build script:
 ./build.sh
 ```
 
-Every time `./build.sh` is executed:
-1. It automatically increments the patch version (e.g. `1.0.0` → `1.0.1`) and build number (e.g. `1` → `2`) in `Info.plist`.
-2. Compiles the Metal shaders into `default.metallib`.
-3. Compiles the Swift application.
-4. Codesigns the app bundle ad-hoc.
-5. Installs the new version directly to `/Applications/macTilt.app`.
+The script compiles both architectures, signs the bundles, creates a DMG, and installs to `/Applications`.
+Build outputs stay in the ignored `build/` directory. To build without installing:
+
+```bash
+./build.sh --no-install
+```
+
+Ad-hoc signing is the default and does not require an Apple Developer account.
+To use your own certificate, pass its SHA-1 fingerprint through `SIGNING_IDENTITY`;
+do not commit certificate files or local signing configuration.
+
+Optional `APP_VERSION` and `BUILD_NUMBER` environment variables override version
+metadata only in the generated app bundle. Building never increments or modifies
+the tracked `Info.plist`.
+
 
 ---
 
@@ -72,3 +81,14 @@ The menu bar icon will display your current lid status. The Liquid Glass control
 ## Credits & Acknowledgements
 
 - **Lid Angle Sensor**: Inspired by hardware reverse-engineering documented in [samhenrigold/LidAngleSensor](https://github.com/samhenrigold/LidAngleSensor) by [@samhenrigold](https://github.com/samhenrigold).
+
+
+## 中文本地增强版：后台运行
+
+关闭控制面板后，应用仍在菜单栏运行。使用 `--background` 参数启动时不弹出设置窗口。
+如需登录自启动，可在当前用户下配置 LaunchAgent： `~/Library/LaunchAgents/com.lqsky7.mactilt.background.plist`，
+登录后运行 `/Applications/macTilt.app/Contents/MacOS/macTilt --background`。
+启用该启动项后，下次登录会在后台启动。菜单栏“退出 macTilt”仍可正常退出。
+
+锁屏显示空间的实现参考 [SkyLightWindow](https://github.com/Lakr233/SkyLightWindow)，
+MIT 许可见 `Resources/ThirdParty/SkyLightWindow-LICENSE.txt`。

--- a/README.md
+++ b/README.md
@@ -7,27 +7,29 @@ The **macTilt** 3D clamshell fold animation for MacBooks driven by the physical 
 Rather than rendering inside a separate window, **the entire macOS display follows the animation in 3D space as you close your MacBook lid**.
 
 ## NOTE
-- **锁屏开盖动画（本地增强版）**：通过 SkyLight 私有显示空间呈现壁纸展开动画。唤醒时补充 0.8 秒展开过渡；锁定期间以 60 Hz 持续读取开合角度，反复合盖、开盖均可触发，没有动画截止时间。系统真正睡眠时进程暂停，唤醒后恢复。接口可能随系统更新变化；不适用于重启后的 FileVault 预启动解锁界面。
+- **Lock Screen Animation**: Unfolds the wallpaper on the lock screen through a private SkyLight display space. It requires System Integrity Protection (SIP) to be disabled; while SIP is enabled, the option is greyed out in the control panel. Waking adds a 0.8-second unfold transition. While the Mac is locked, the lid angle is read at 60 Hz, so closing and opening the lid repeatedly keeps animating with no time limit. The process pauses during real system sleep and resumes on wake. The private interface may change with macOS updates, and it does not apply to the FileVault pre-boot unlock screen after a restart.
 - **Normal MacBook Use**: When you are actively using your MacBook (lid is open), the app does **nothing** (overlay is completely hidden, zero CPU/GPU overhead, full click-through).
-- **Closing MacBook**: As you tilt the screen closed, the display freezes the screen and seamlessly folds **from up to down** toward the bottom keyboard hinge into the dark void.
+- **Closing MacBook**: As you tilt the screen closed, the picture stays frozen at the start angle while the display closes through it; the top frosts over and slips into the dark void first.
 ---
 
 ## Features
 
 - 📐 **Physical Lid Angle Sensing**: Real-time 60 Hz polling of Apple's internal lid angle sensor (`IOHIDDevice` Vendor `0x05AC`, Product `0x8104`, UsagePage `0x0020`, Usage `0x008A`).
-- 🌊 **Exact 1:1 Shaders**: Native Metal Shading Language implementation:
-  - 3D perspective projection with up-to-down clamshell hinge bend
-  - 5-tap separable Gaussian blur mip chain
-  - Glass tint and specular rim reflections
-  - Dark void horizon falloff
+- 🌊 **Fold Shader**: Native Metal Shading Language implementation:
+  - The picture stays frozen at the start angle while the display closes through it (fixed front-view projection, as on iPhone Duo)
+  - Frost and darkening grow with the depth between the glass and the picture, so the top of the display goes dark first
+  - Soft, rounded picture edges; hidden areas show a dim glow of scattered light instead of flat black
+  - Frost blur averaged in linear light with a vibrancy boost, on smoked glass that dims as the lid closes
+  - Optional glass reflection sheen
 - 🖥️ **Full-Screen Seamless Overlay**: Spans the entire screen at `.screenSaver` level. Completely click-through and invisible when open, freezing and folding into 3D space on tilt.
 - 🎛️ **Liquid Glass Desktop App**: Built with crisp native styling and Swift native `.glass` APIs (`.glassEffect()`, `.buttonStyle(.glass)`, `.buttonStyle(.glassProminent)`):
   - **Menu Bar Display Toggle**: Option to hide or show the numerical lid sensor angle from the menu bar.
   - **Screen Recording Permission Check**: Real-time permission status check and one-click authorization request.
-  - **Tilt Trigger Customization**: Customize exactly when the animation starts (e.g. 80°) and when full fold is reached (e.g. 3°).
+  - **Tilt Trigger Customization**: Choose the start angle, where the picture stays while the lid closes (e.g. 115°), and the end angle, where the display is fully dark (e.g. 3°).
   - **Follow Responsiveness**: Tune the exponential smoothing physics.
   - **Image Source**: Live Screen Capture (`ScreenCaptureKit`), Desktop Wallpaper, Bundled Artwork, or Custom Photo.
-  - **Test Preview Slider**: Scrub and preview the up-to-down closing fold interactively without moving your MacBook lid.
+  - **Test Preview Slider**: Scrub through the fold interactively without moving your MacBook lid.
+  - **Language**: Switch the interface between English and Simplified Chinese, or follow the system language.
 - 🍸 **Menu Bar Extra**: Quick angle readout (e.g. `126°`), status monitoring, and settings shortcuts.
 - 🚀 **Automated Build & Install (`build.sh`)**: Builds without modifying source version metadata and installs the `.app` directly to `/Applications`.
 
@@ -37,6 +39,7 @@ Rather than rendering inside a separate window, **the entire macOS display follo
 
 - macOS 14.0 or later (Apple Silicon or Intel MacBook with lid angle sensor)
 - Xcode Command Line Tools (`swiftc`, `xcrun metal`)
+- The lock screen animation additionally requires SIP to be disabled
 
 ---
 
@@ -59,6 +62,12 @@ Ad-hoc signing is the default and does not require an Apple Developer account.
 To use your own certificate, pass its SHA-1 fingerprint through `SIGNING_IDENTITY`;
 do not commit certificate files or local signing configuration.
 
+macOS ties the Screen Recording permission to the code signature. An ad-hoc build
+gets a new signature every time, so grant the permission again after rebuilding;
+a certificate keeps the signature stable across builds. A personal Apple Development
+certificate also records its name, including your email address, in the signature,
+so keep such builds local and share ad-hoc builds instead.
+
 Optional `APP_VERSION` and `BUILD_NUMBER` environment variables override version
 metadata only in the generated app bundle. Building never increments or modifies
 the tracked `Info.plist`.
@@ -76,19 +85,16 @@ open /Applications/macTilt.app
 
 The menu bar icon will display your current lid status. The Liquid Glass control panel allows you to customize the tilt thresholds and test the animation live!
 
+### Running in the Background
+
+macTilt keeps running in the menu bar after the control panel is closed. Launch it with `--background` to skip opening the settings window.
+To start it at login, add a LaunchAgent for the current user, such as `~/Library/LaunchAgents/com.lqsky7.mactilt.background.plist`,
+that runs `/Applications/macTilt.app/Contents/MacOS/macTilt --background`.
+Once enabled, macTilt starts in the background at your next login. **Quit macTilt** in the menu bar still quits it normally.
+
 ---
 
 ## Credits & Acknowledgements
 
 - **Lid Angle Sensor**: Inspired by hardware reverse-engineering documented in [samhenrigold/LidAngleSensor](https://github.com/samhenrigold/LidAngleSensor) by [@samhenrigold](https://github.com/samhenrigold).
-
-
-## 中文本地增强版：后台运行
-
-关闭控制面板后，应用仍在菜单栏运行。使用 `--background` 参数启动时不弹出设置窗口。
-如需登录自启动，可在当前用户下配置 LaunchAgent： `~/Library/LaunchAgents/com.lqsky7.mactilt.background.plist`，
-登录后运行 `/Applications/macTilt.app/Contents/MacOS/macTilt --background`。
-启用该启动项后，下次登录会在后台启动。菜单栏“退出 macTilt”仍可正常退出。
-
-锁屏显示空间的实现参考 [SkyLightWindow](https://github.com/Lakr233/SkyLightWindow)，
-MIT 许可见 `Resources/ThirdParty/SkyLightWindow-LICENSE.txt`。
+- **Lock Screen Display Space**: Based on [Lakr233/SkyLightWindow](https://github.com/Lakr233/SkyLightWindow) (MIT); see `Resources/ThirdParty/SkyLightWindow-LICENSE.txt`.

--- a/Resources/ScreenSaver-Info.plist
+++ b/Resources/ScreenSaver-Info.plist
@@ -3,7 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>zh_CN</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>zh-Hans</string>
+	</array>
 	<key>CFBundleDisplayName</key>
 	<string>macTilt</string>
 	<key>CFBundleExecutable</key>

--- a/Resources/ScreenSaver-Info.plist
+++ b/Resources/ScreenSaver-Info.plist
@@ -3,9 +3,10 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>zh_CN</string>
+	<string>en</string>
 	<key>CFBundleLocalizations</key>
 	<array>
+		<string>en</string>
 		<string>zh-Hans</string>
 	</array>
 	<key>CFBundleDisplayName</key>

--- a/Resources/ThirdParty/SkyLightWindow-LICENSE.txt
+++ b/Resources/ThirdParty/SkyLightWindow-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Lakr Aream
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -14,7 +14,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         sensor.onTurnUpdate = { turn, angle in
             OverlayWindowController.shared.update(turn: turn, angle: angle)
             MenuBarController.shared.updateAngleDisplay(angle: angle, isConnected: AppSettings.shared.isSensorConnected)
-            SharedStateManager.shared.broadcast(angle: angle, turn: turn)
+            SharedStateManager.shared.broadcast(angle: angle, turn: turn,
+                                                lidTravel: AppSettings.shared.startTiltAngle - AppSettings.shared.endTiltAngle)
         }
         sensor.start()
         

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -19,6 +19,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         sensor.start()
         
         // On first launch, open the Apple HCI Onboarding window; otherwise open the control panel
+        guard !CommandLine.arguments.contains("--background") else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             if !AppSettings.shared.hasCompletedOnboarding {
                 MenuBarController.shared.openOnboardingWindow()
@@ -28,6 +29,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
     
+    public func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+
     public func applicationWillTerminate(_ notification: Notification) {
         LidSensor.shared.stop()
     }

--- a/Sources/AppSettings.swift
+++ b/Sources/AppSettings.swift
@@ -117,7 +117,9 @@ public final class AppSettings: ObservableObject {
         self.reflectionIntensity = defaults.object(forKey: kReflectionIntensity) != nil ? defaults.double(forKey: kReflectionIntensity) : 0.0
         
         self.showAngleInMenuBar = defaults.object(forKey: kShowAngleInMenuBar) != nil ? defaults.bool(forKey: kShowAngleInMenuBar) : true
-        self.enableLockScreenPriority = defaults.object(forKey: kEnableLockScreenPriority) != nil ? defaults.bool(forKey: kEnableLockScreenPriority) : true
+        // The lock-screen space needs SIP off; the saved choice comes back once it is.
+        self.enableLockScreenPriority = !LockScreenSpace.isSIPEnabled
+            && (defaults.object(forKey: kEnableLockScreenPriority) != nil ? defaults.bool(forKey: kEnableLockScreenPriority) : true)
         
         // Listen for app becoming active to re-check permissions immediately
         NotificationCenter.default.addObserver(

--- a/Sources/AppSettings.swift
+++ b/Sources/AppSettings.swift
@@ -12,10 +12,57 @@ public enum ImageSourceMode: Int, CaseIterable, Identifiable {
     
     public var title: String {
         switch self {
-        case .liveCapture: return "实时屏幕捕获"
-        case .desktopWallpaper: return "桌面壁纸"
-        case .bundledArtwork: return "内置图片"
-        case .customImage: return "自定义图片"
+        case .liveCapture: return tr("实时屏幕捕获", "Live Screen Capture")
+        case .desktopWallpaper: return tr("桌面壁纸", "Desktop Wallpaper")
+        case .bundledArtwork: return tr("内置图片", "Bundled Artwork")
+        case .customImage: return tr("自定义图片", "Custom Image")
+        }
+    }
+}
+
+public enum AppLanguage: String, CaseIterable, Identifiable {
+    case system
+    case chinese = "zh-Hans"
+    case english = "en"
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .system: return tr("跟随系统", "System")
+        case .chinese: return "中文"
+        case .english: return "English"
+        }
+    }
+}
+
+/// Returns the Simplified Chinese or English copy for the current interface language.
+public func tr(_ chinese: String, _ english: String) -> String {
+    AppSettings.shared.usesChinese ? chinese : english
+}
+
+public enum LockScreenStatus {
+    case initializing, needsSIPDisabled, configured, unavailable
+
+    public var text: String {
+        switch self {
+        case .initializing: return tr("正在初始化锁屏显示接口…", "Setting up the lock screen display…")
+        case .needsSIPDisabled: return tr("需要先关闭系统完整性保护（SIP）", "Requires System Integrity Protection (SIP) to be disabled")
+        case .configured: return tr("已配置锁屏接口（待实际开盖验证）", "Lock screen display configured (confirm by opening the lid)")
+        case .unavailable: return tr("锁屏显示接口不可用", "Lock screen display unavailable")
+        }
+    }
+}
+
+public enum SensorStatus {
+    case initializing, managerUnavailable, connected, notFound
+
+    public var text: String {
+        switch self {
+        case .initializing: return tr("正在初始化传感器…", "Initializing sensor…")
+        case .managerUnavailable: return tr("无法初始化 IOHIDManager。", "Could not initialize IOHIDManager.")
+        case .connected: return tr("屏幕开合角度传感器已连接。", "Lid angle sensor connected.")
+        case .notFound: return tr("未在此 Mac 上检测到屏幕开合角度传感器。", "No lid angle sensor found on this Mac.")
         }
     }
 }
@@ -34,6 +81,7 @@ public final class AppSettings: ObservableObject {
     private let kShowAngleInMenuBar = "mactilt_showAngleInMenuBar"
     private let kEnableLockScreenPriority = "mactilt_enable_lock_screen_priority"
     private let kHasCompletedOnboarding = "mactilt_hasCompletedOnboarding"
+    private let kLanguage = "mactilt_language"
     
     // MARK: - Customizable Animation Options
     @Published public var hasCompletedOnboarding: Bool {
@@ -81,9 +129,25 @@ public final class AppSettings: ObservableObject {
             OverlayWindowController.shared.updateWindowLevel()
         }
     }
+
+    @Published public var language: AppLanguage {
+        didSet {
+            UserDefaults.standard.set(language.rawValue, forKey: kLanguage)
+            MenuBarController.shared.refreshLocalizedText()
+        }
+    }
+
+    /// Whether the interface is shown in Simplified Chinese.
+    public var usesChinese: Bool {
+        switch language {
+        case .chinese: return true
+        case .english: return false
+        case .system: return Locale.preferredLanguages.first?.hasPrefix("zh") ?? false
+        }
+    }
     
     // MARK: - Real-time State
-    @Published public var lockScreenStatus = "正在初始化锁屏显示接口…"
+    @Published public var lockScreenStatus: LockScreenStatus = .initializing
     @Published public var isTestModeActive: Bool = false {
         didSet {
             if !isTestModeActive {
@@ -95,7 +159,7 @@ public final class AppSettings: ObservableObject {
     @Published public var currentLidAngle: Double = 120.0
     @Published public var isSensorConnected: Bool = false
     @Published public var isClosing: Bool = false
-    @Published public var sensorStatusMessage: String = "正在初始化传感器…"
+    @Published public var sensorStatus: SensorStatus = .initializing
     @Published public var hasScreenRecordingPermission: Bool = false
     @Published public var lastCaptureDate: Date? = nil
     @Published public var isScreenCaptureDormant: Bool = true
@@ -105,6 +169,7 @@ public final class AppSettings: ObservableObject {
         
         // Defaults matching User Preferences
         self.hasCompletedOnboarding = defaults.bool(forKey: kHasCompletedOnboarding)
+        self.language = AppLanguage(rawValue: defaults.string(forKey: kLanguage) ?? "") ?? .system
         self.startTiltAngle = defaults.object(forKey: kStartTiltAngle) != nil ? defaults.double(forKey: kStartTiltAngle) : 115.0
         self.endTiltAngle = defaults.object(forKey: kEndTiltAngle) != nil ? defaults.double(forKey: kEndTiltAngle) : 3.0
         self.followSpeed = defaults.object(forKey: kFollowSpeed) != nil ? defaults.double(forKey: kFollowSpeed) : 16.0

--- a/Sources/AppSettings.swift
+++ b/Sources/AppSettings.swift
@@ -12,10 +12,10 @@ public enum ImageSourceMode: Int, CaseIterable, Identifiable {
     
     public var title: String {
         switch self {
-        case .liveCapture: return "Live Screen Capture"
-        case .desktopWallpaper: return "Desktop Wallpaper"
-        case .bundledArtwork: return "Bundled Artwork"
-        case .customImage: return "Custom Image"
+        case .liveCapture: return "实时屏幕捕获"
+        case .desktopWallpaper: return "桌面壁纸"
+        case .bundledArtwork: return "内置图片"
+        case .customImage: return "自定义图片"
         }
     }
 }
@@ -83,6 +83,7 @@ public final class AppSettings: ObservableObject {
     }
     
     // MARK: - Real-time State
+    @Published public var lockScreenStatus = "正在初始化锁屏显示接口…"
     @Published public var isTestModeActive: Bool = false {
         didSet {
             if !isTestModeActive {
@@ -94,7 +95,7 @@ public final class AppSettings: ObservableObject {
     @Published public var currentLidAngle: Double = 120.0
     @Published public var isSensorConnected: Bool = false
     @Published public var isClosing: Bool = false
-    @Published public var sensorStatusMessage: String = "Initializing sensor..."
+    @Published public var sensorStatusMessage: String = "正在初始化传感器…"
     @Published public var hasScreenRecordingPermission: Bool = false
     @Published public var lastCaptureDate: Date? = nil
     @Published public var isScreenCaptureDormant: Bool = true

--- a/Sources/FoldShaders.metal
+++ b/Sources/FoldShaders.metal
@@ -1,14 +1,38 @@
 #include <metal_stdlib>
 using namespace metal;
 
-constant float MAX_TILT = 0.84106867; // acos(1.0 / 1.5)
-constant float3 DARK = float3(0.003, 0.004, 0.005);
+// The picture freezes on the plane the display occupied at the start angle.
+// Closing the lid turns the glass toward the viewer about the hinge, and each
+// pixel shows the frozen picture along a fixed front-view ray: the picture
+// holds still in space while the display sweeps through it. The farther the
+// glass has swung away from the picture, the deeper the view behind it, so the
+// top of the display frosts over first and sinks into a dim glow of scattered
+// light, which fades to black by the end angle.
+
+constant float EYE_DISTANCE = 2.6;      // reference viewer on the picture's centre normal, in display heights
+constant float SWEEP_KNEE = 0.79;       // 45°: up to here the glass follows the lid exactly
+constant float MAX_SWEEP = 1.08;        // 62°: past the knee the glass eases toward this instead of turning edge-on
+constant float HAZE_DENSITY = 4.0;      // how quickly depth hides the picture
+constant float FROST_PER_DEPTH = 0.06;  // blur radius in picture heights per display height of depth
+constant float FADE_START = 0.45;       // fold progress where the whole display starts fading; black at the end angle
+constant float CORNER_RADIUS = 0.035;   // rounded top corners of the frozen picture, in display heights
+constant float EDGE_SOFTNESS = 2.0;     // picture edge falloff width, relative to the frost radius
+constant float GLOW = 0.2;              // share of the picture's light the frosted glass scatters
+constant float GLOW_REACH = 0.12;       // how far scattered light spills past the picture edge, in display heights
+constant float VIBRANCY = 0.3;          // extra saturation once fully frosted
+constant float AMBIENT_LOD = 6.0;       // mip level that supplies the scattered light
+constant float SMOKE = 0.22;            // how much the whole glass has dimmed by the knee, like smoked glass
+constant float3 VOID_COLOR = float3(0.003, 0.004, 0.005);
+
+constant int FROST_TAPS = 12;
+constant float GOLDEN_ANGLE = 2.39996323;
 
 struct Uniforms {
-    float2 imageSize;
-    float2 cover;
-    float aspect;
-    float turn;
+    float2 imageSize;          // texture size in pixels
+    float2 cover;              // aspect-fill scale from picture to texture coordinates
+    float aspect;              // display width / height
+    float turn;                // fold progress: 0 at the start angle, 1 at the end angle
+    float sweep;               // radians the lid has turned away from the picture
     float blurStrength;
     float reflectionIntensity;
 };
@@ -19,151 +43,117 @@ struct VertexOut {
 };
 
 vertex VertexOut foldVertex(uint vid [[vertex_id]]) {
-    const float2 positions[6] = {
-        float2(-1.0, -1.0),
-        float2( 1.0, -1.0),
-        float2(-1.0,  1.0),
-        float2(-1.0,  1.0),
-        float2( 1.0, -1.0),
-        float2( 1.0,  1.0)
-    };
-    
+    // One oversized triangle covers the viewport without a diagonal seam.
+    float2 pos = float2(vid == 1 ? 3.0 : -1.0, vid == 2 ? 3.0 : -1.0);
     VertexOut out;
-    float2 pos = positions[vid];
     out.position = float4(pos, 0.0, 1.0);
     // UV origin: (0,0) at top-left, (1,1) at bottom-right
     out.uv = float2(pos.x * 0.5 + 0.5, 0.5 - pos.y * 0.5);
     return out;
 }
 
-inline float3 sampleSmoothMatteBlur(texture2d<float> tex,
-                                    sampler s,
-                                    float2 uv,
-                                    float radius,
-                                    float2 cover,
-                                    float2 uiPixel,
-                                    float2 screenCoord) {
-    float2 tuv = (uv - 0.5) * cover + 0.5;
-    
-    // When radius is near zero, return razor-sharp native Retina sample at level 0
-    if (radius <= 0.15) {
-        return tex.sample(s, tuv, level(0.0)).rgb;
-    }
-    
-    // CRITICAL FIX FOR PIXELATION:
-    // Previously, `lod = log2(radius)` scaled unchecked into levels 4-6 (45x29 texels),
-    // causing massive pixel blocks and severe aliasing that worsened with tilt.
-    //
-    // By keeping the base LOD tightly bounded (capped at 1.85), texels are never larger
-    // than 3-4 physical screen pixels. Combined with a dense 32-sample Vogel Disc
-    // (Golden Angle spiral) and trilinear filtering, the blur is 100% continuous,
-    // velvety, and free of blocky pixelation at all tilt angles.
-    float baseLod = clamp(log2(max(1.0, radius * 0.18)), 0.0, 1.85);
-    
-    // Subtle sub-pixel micro-rotation per screen pixel eliminates ring banding
-    // and produces a natural, tactile frosted-glass matte dispersion.
-    float rot = (fract(sin(dot(screenCoord, float2(12.9898, 78.233))) * 43758.5453) - 0.5) * 0.35;
-    float cosRot = cos(rot);
-    float sinRot = sin(rot);
-    
-    float3 accum = float3(0.0);
-    float totalWeight = 0.0;
-    
-    // 32-sample Vogel Disc (Golden Angle Fermat Spiral)
-    constexpr int NUM_SAMPLES = 32;
-    constexpr float GOLDEN_ANGLE = 2.39996323; // pi * (3.0 - sqrt(5.0))
-    
-    for (int i = 0; i < NUM_SAMPLES; i++) {
-        float fi = float(i);
-        float theta = fi * GOLDEN_ANGLE;
-        // Square root progression provides uniform area density across the disc
-        float r = sqrt((fi + 0.5) / float(NUM_SAMPLES));
-        
-        // Direction rotated by micro-jitter
-        float uX = cos(theta);
-        float uY = sin(theta);
-        float dirX = uX * cosRot - uY * sinRot;
-        float dirY = uX * sinRot + uY * cosRot;
-        
-        float2 offset = float2(dirX, dirY) * (r * radius * uiPixel);
-        float2 sampleUV = clamp(tuv + offset, 0.0, 1.0);
-        
-        // Gaussian optical falloff from center of blur disc
-        float weight = exp(-2.3 * r * r);
-        
-        // Center samples draw fine details; perimeter samples blend into smooth mip
-        float sampleLod = mix(0.0, baseLod, smoothstep(0.1, 0.85, r));
-        
-        accum += tex.sample(s, sampleUV, level(sampleLod)).rgb * weight;
-        totalWeight += weight;
-    }
-    
-    float3 blurred = accum / totalWeight;
-    
-    // Soft matte ambient scatter (frosted glass diffusion characteristic)
-    float matteScatter = 0.015 * smoothstep(0.0, 20.0, radius);
-    blurred = blurred + float3(matteScatter);
-    
-    // Smooth transition from sharp to matte blur as fold begins
-    float3 sharp = tex.sample(s, tuv, level(0.0)).rgb;
-    return mix(sharp, blurred, smoothstep(0.0, 2.0, radius));
+// Interleaved gradient noise: a stable per-pixel value in [0, 1).
+inline float gradientNoise(float2 pixel) {
+    return fract(52.9829189 * fract(dot(pixel, float2(0.06711056, 0.00583715))));
+}
+
+// Texture coordinates for a picture position, clamped to the picture.
+inline float2 textureUV(float2 uv, float2 cover) {
+    return (saturate(uv) - 0.5) * cover + 0.5;
+}
+
+// Signed distance to the frozen picture in display heights: rounded top corners,
+// square bottom corners along the hinge.
+inline float pictureDistance(float2 hit, float aspect, float radius) {
+    float2 p = hit - float2(0.0, 0.5);
+    float r = p.y > 0.0 ? radius : 0.0;
+    float2 q = abs(p) - float2(0.5 * aspect, 0.5) + r;
+    return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r;
 }
 
 fragment float4 foldFragment(VertexOut in [[stage_in]],
                              texture2d<float> tex [[texture(0)]],
                              sampler s [[sampler(0)]],
                              constant Uniforms &u [[buffer(0)]]) {
-    float turn = clamp(u.turn, 0.0, 1.0);
-    float2 uiPixel = 2.0 / max(float2(1.0), u.imageSize);
-    
-    if (turn <= 0.00001) {
-        return float4(sampleSmoothMatteBlur(tex, s, in.uv, 0.0, u.cover, uiPixel, in.position.xy), 1.0);
+    if (u.turn <= 0.0 && u.sweep <= 0.0) {
+        return float4(tex.sample(s, (in.uv - 0.5) * u.cover + 0.5, level(0.0)).rgb, 1.0);
     }
-    
-    // Up-to-Down Clamshell Fold: Hinge is at the bottom edge (in.uv.y = 1.0)
-    float fromHinge = clamp(1.0 - in.uv.y, 0.0, 1.0);
-    
-    // Scale bend smoothly across the ENTIRE 0.0 -> 1.0 closing turn
-    float bend = turn * MAX_TILT;
-    float cosine = cos(bend);
-    float sine = sin(bend);
-    
-    // Stable perspective projection that spans the whole closing arc without exploding
-    float invAspect = 1.0 / max(0.1, u.aspect);
-    float eye = 3.2 * max(invAspect, 1.0);
-    float depth = fromHinge * (0.80 * invAspect) * sine;
-    float perspective = eye / max(0.01, (eye - depth));
-    
-    float2 plane;
-    plane.y = 1.0 - fromHinge * cosine * perspective;
-    plane.x = 0.5 + (in.uv.x - 0.5) * perspective;
-    
-    // Defocus blur: smooth progression that remains continuous and silky
-    float blurSpread = pow(smoothstep(0.0, 0.85, fromHinge), 1.2);
-    float motion = smoothstep(0.0, 1.0, turn) * mix(0.20, 1.0, blurSpread);
-    float radius = 56.0 * motion * max(0.05, u.blurStrength);
-    
-    // Side margins softness
-    float softness = fwidth(in.uv.x) + radius * 0.002;
-    float mask = 1.0 - smoothstep(0.5 - softness, 0.5 + softness, abs(plane.x - 0.5));
-    
-    // Sample texture using 32-sample Vogel disc continuous matte blur
-    float3 color = sampleSmoothMatteBlur(tex, s, plane, radius, u.cover, uiPixel, in.position.xy);
-    
-    // Glass refraction & reflection
-    float glass = sine * pow(fromHinge, 1.5);
-    color *= 1.0 - 0.20 * glass;
-    float reflection = exp(-pow((fromHinge - 0.65) / 0.35, 2.0)) * sine;
-    color += float3(0.82, 0.85, 0.86) * reflection * (0.025 * u.reflectionIntensity);
-    
-    // Smooth void fade: gradual falloff that only fully darkens at the very end
-    float fadeDistance = clamp((fromHinge - 0.20) / 0.80, 0.0, 1.0);
-    float voidAmount = pow(turn, 1.1) * fadeDistance;
-    color *= (1.0 - 0.80 * voidAmount);
-    
-    // Final closure into deep black right as the lid completely shuts (turn > 0.90)
-    float finalClose = 1.0 - smoothstep(0.90, 1.0, turn);
-    color *= finalClose;
-    
-    return float4(mix(DARK, color, mask * finalClose), 1.0);
+
+    // Near edge-on the whole display would map onto a sliver of the picture, so ease off past the knee.
+    float sweep = max(u.sweep, 0.0);
+    if (sweep > SWEEP_KNEE) {
+        float span = MAX_SWEEP - SWEEP_KNEE;
+        sweep = SWEEP_KNEE + span * (1.0 - exp((SWEEP_KNEE - sweep) / span));
+    }
+    float height = 1.0 - in.uv.y;   // 0 at the hinge, 1 at the top edge
+
+    // Glass position in picture space (display heights): x across, y up the picture, z toward the viewer.
+    float3 glass = float3((in.uv.x - 0.5) * u.aspect, height * cos(sweep), height * sin(sweep));
+
+    // Follow the fixed front-view ray through the glass back to the picture plane (z = 0).
+    const float3 eye = float3(0.0, 0.5, EYE_DISTANCE);
+    float2 hit = eye.xy + (glass.xy - eye.xy) * (eye.z / (eye.z - glass.z));
+    float2 uv = float2(hit.x / u.aspect + 0.5, 1.0 - hit.y);
+
+    // Screen-space footprint, measured before any early exit.
+    float2 texels = u.imageSize * u.cover;
+    float2 dx = dfdx(uv) * texels;
+    float2 dy = dfdy(uv) * texels;
+    float baseLod = max(0.0, 0.5 * log2(max(dot(dx, dx), dot(dy, dy))));
+    float pixelSpan = max(max(fwidth(hit.x), fwidth(hit.y)), 1e-5);
+
+    float closing = 1.0 - smoothstep(FADE_START, 1.0, saturate(u.turn));
+    if (closing < 0.004) {
+        return float4(VOID_COLOR, 1.0);
+    }
+
+    float depth = glass.z;
+    float radius = u.blurStrength * FROST_PER_DEPTH * depth * texels.y;   // in texels
+    float2 center = textureUV(uv, u.cover);
+
+    // Soft, rounded picture edge; the falloff widens with the frost and stays outside the picture.
+    float corner = CORNER_RADIUS * smoothstep(0.0, 0.35, sweep);
+    float edge = pictureDistance(hit, u.aspect, corner);
+    float softness = max(pixelSpan, EDGE_SOFTNESS * radius / texels.y);
+    float coverage = 1.0 - smoothstep(0.0, softness, edge);
+    float visible = coverage * exp(-HAZE_DENSITY * depth * depth);
+
+    // Frosted glass scatters some of the picture's light where the picture itself is hidden.
+    float3 ambient = tex.sample(s, center, level(AMBIENT_LOD)).rgb;
+    float3 color = ambient * (GLOW * exp(-max(edge, 0.0) / GLOW_REACH));
+
+    if (visible > 0.004) {
+        float3 picture;
+        if (radius < 0.5) {
+            picture = tex.sample(s, center, level(baseLod)).rgb;
+        } else {
+            // Vogel disc averaged in roughly linear light, so bright details bloom instead of greying out.
+            float lod = max(baseLod, log2(radius * 0.5));
+            float2 reach = radius / texels;
+            float spin = 6.2831853 * gradientNoise(in.position.xy);
+            float3 sum = 0.0;
+            float weight = 0.0;
+            for (int i = 0; i < FROST_TAPS; i++) {
+                float r = sqrt((float(i) + 0.5) / float(FROST_TAPS));
+                float a = float(i) * GOLDEN_ANGLE + spin;
+                float w = exp(-2.0 * r * r);
+                float3 tap = tex.sample(s, textureUV(uv + float2(cos(a), sin(a)) * (r * reach), u.cover), level(lod)).rgb;
+                sum += tap * tap * w;
+                weight += w;
+            }
+            picture = sqrt(sum / weight);
+            float luma = dot(picture, float3(0.2126, 0.7152, 0.0722));
+            picture = saturate(mix(float3(luma), picture, 1.0 + VIBRANCY * saturate(radius / 24.0)));
+        }
+        color = mix(color, picture * (1.0 - SMOKE * smoothstep(0.0, SWEEP_KNEE, sweep)), visible);
+    }
+
+    // A soft reflection band drifts down the glass as it tilts.
+    float lift = sin(sweep);
+    float band = exp(-pow((height - 0.85 + 0.5 * lift) / 0.28, 2.0));
+    float3 sheen = float3(0.82, 0.85, 0.86) * (band * lift * 0.035 * u.reflectionIntensity);
+
+    float3 result = (color + sheen) * closing;
+    result += (gradientNoise(in.position.xy + 61.0) - 0.5) / 255.0;   // dither the long dark ramp
+    return float4(result, 1.0);
 }

--- a/Sources/LidSensor.swift
+++ b/Sources/LidSensor.swift
@@ -69,7 +69,7 @@ public final class LidSensor {
     private func setupManager() {
         let manager = IOHIDManagerCreate(kCFAllocatorDefault, Self.noOptions)
         guard IOHIDManagerOpen(manager, Self.noOptions) == kIOReturnSuccess else {
-            AppSettings.shared.sensorStatusMessage = "无法初始化 IOHIDManager。"
+            AppSettings.shared.sensorStatus = .managerUnavailable
             AppSettings.shared.isSensorConnected = false
             return
         }
@@ -86,7 +86,7 @@ public final class LidSensor {
         if let devices = IOHIDManagerCopyDevices(manager) as? Set<IOHIDDevice>, let device = devices.first {
             self.hidDevice = device
             AppSettings.shared.isSensorConnected = true
-            AppSettings.shared.sensorStatusMessage = "屏幕开合角度传感器已连接。"
+            AppSettings.shared.sensorStatus = .connected
         } else {
             // Fallback: search across all 0x8104 devices for page 32 usage 138
             let fallbackMatching: [String: Any] = [
@@ -101,7 +101,7 @@ public final class LidSensor {
                     if page == 32 && usage == 138 {
                         self.hidDevice = dev
                         AppSettings.shared.isSensorConnected = true
-                        AppSettings.shared.sensorStatusMessage = "屏幕开合角度传感器已连接。"
+                        AppSettings.shared.sensorStatus = .connected
                         break
                     }
                 }
@@ -110,7 +110,7 @@ public final class LidSensor {
         
         if self.hidDevice == nil {
             AppSettings.shared.isSensorConnected = false
-            AppSettings.shared.sensorStatusMessage = "未在此 Mac 上检测到屏幕开合角度传感器。"
+            AppSettings.shared.sensorStatus = .notFound
         }
     }
     

--- a/Sources/LidSensor.swift
+++ b/Sources/LidSensor.swift
@@ -53,6 +53,11 @@ public final class LidSensor {
             IOHIDDeviceClose(device, Self.noOptions)
             isDeviceOpen = false
         }
+        if let manager = hidManager { IOHIDManagerClose(manager, Self.noOptions) }
+        hidDevice = nil
+        hidManager = nil
+        lastTime = nil
+        hasPreArmedInThisMotion = false
         setupManager()
         if let device = hidDevice {
             if IOHIDDeviceOpen(device, Self.noOptions) == kIOReturnSuccess {
@@ -64,7 +69,7 @@ public final class LidSensor {
     private func setupManager() {
         let manager = IOHIDManagerCreate(kCFAllocatorDefault, Self.noOptions)
         guard IOHIDManagerOpen(manager, Self.noOptions) == kIOReturnSuccess else {
-            AppSettings.shared.sensorStatusMessage = "Failed to initialize IOHIDManager."
+            AppSettings.shared.sensorStatusMessage = "无法初始化 IOHIDManager。"
             AppSettings.shared.isSensorConnected = false
             return
         }
@@ -81,7 +86,7 @@ public final class LidSensor {
         if let devices = IOHIDManagerCopyDevices(manager) as? Set<IOHIDDevice>, let device = devices.first {
             self.hidDevice = device
             AppSettings.shared.isSensorConnected = true
-            AppSettings.shared.sensorStatusMessage = "Lid Angle Sensor connected."
+            AppSettings.shared.sensorStatusMessage = "屏幕开合角度传感器已连接。"
         } else {
             // Fallback: search across all 0x8104 devices for page 32 usage 138
             let fallbackMatching: [String: Any] = [
@@ -96,7 +101,7 @@ public final class LidSensor {
                     if page == 32 && usage == 138 {
                         self.hidDevice = dev
                         AppSettings.shared.isSensorConnected = true
-                        AppSettings.shared.sensorStatusMessage = "Lid Angle Sensor connected."
+                        AppSettings.shared.sensorStatusMessage = "屏幕开合角度传感器已连接。"
                         break
                     }
                 }
@@ -105,7 +110,7 @@ public final class LidSensor {
         
         if self.hidDevice == nil {
             AppSettings.shared.isSensorConnected = false
-            AppSettings.shared.sensorStatusMessage = "No Lid Angle Sensor detected on this Mac."
+            AppSettings.shared.sensorStatusMessage = "未在此 Mac 上检测到屏幕开合角度传感器。"
         }
     }
     

--- a/Sources/LiquidGlassView.swift
+++ b/Sources/LiquidGlassView.swift
@@ -103,7 +103,7 @@ public struct LiquidGlassControlPanel: View {
                     .font(.title3)
                     .fontWeight(.bold)
                 
-                Text("MacBook Clamshell Fold Animation")
+                Text("MacBook 合盖折叠动画")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -137,28 +137,28 @@ public struct LiquidGlassControlPanel: View {
     
     private var angleStatusText: String {
         if settings.currentLidAngle >= settings.startTiltAngle {
-            return "Using Mac (Open)"
+            return "正常使用（已开盖）"
         } else if settings.currentLidAngle <= settings.endTiltAngle {
-            return "Lid Closed"
+            return "已合盖"
         } else {
             let pct = Int(settings.normalizedTurn(for: settings.currentLidAngle) * 100)
-            return "Fold (\(pct)%)"
+            return "折叠中（\(pct)%）"
         }
     }
     
     // MARK: - Screen Recording Permission Card
     private var permissionCard: some View {
-        HCISectionCard(title: "Screen Recording Permission", icon: "video.badge.checkmark") {
+        HCISectionCard(title: "屏幕录制权限", icon: "video.badge.checkmark") {
             HStack(spacing: 10) {
                 Image(systemName: settings.hasScreenRecordingPermission ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
                     .foregroundStyle(settings.hasScreenRecordingPermission ? Color.green : Color.orange)
                     .font(.system(size: 15))
                 
-                Text(settings.hasScreenRecordingPermission ? "Permission Active" : "Permission Required")
+                Text(settings.hasScreenRecordingPermission ? "已授权" : "需要授权")
                     .font(.subheadline)
                     .fontWeight(.medium)
                 
-                InfoButton("Screen Recording", content: "macTilt requires Screen Recording permission to freeze and fold your active desktop in 3D space as you close the lid. All processing is strictly on-device.")
+                InfoButton("屏幕录制", content: "macTilt 需要屏幕录制权限，才能在合盖时捕获当前桌面并呈现 3D 折叠动画。所有处理均在本机完成。")
                 
                 Spacer()
                 
@@ -169,10 +169,10 @@ public struct LiquidGlassControlPanel: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
-                .help("Re-check permission")
+                .help("重新检查权限")
                 
                 if !settings.hasScreenRecordingPermission {
-                    Button("Grant Access") {
+                    Button("前往授权") {
                         if !ScreenCapture.shared.requestPermission() {
                             ScreenCapture.shared.openSettings()
                         }
@@ -190,24 +190,24 @@ public struct LiquidGlassControlPanel: View {
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
-                    .help("Permission troubleshooting")
+                    .help("权限问题排查")
                     .popover(isPresented: $showingPermissionTroubleshooting, arrowEdge: .trailing) {
                         VStack(alignment: .leading, spacing: 10) {
-                            Text("Permission Troubleshooting")
+                            Text("权限问题排查")
                                 .font(.headline)
                             
-                            Text("If already granted in System Settings, macOS requires an app restart to pick up the token.")
+                            Text("如果已在系统设置中授权，请重新启动应用，让 macOS 应用新的权限。")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                             
                             HStack {
-                                Button("Relaunch App") {
+                                Button("重新启动应用") {
                                     ScreenCapture.shared.relaunchApp()
                                 }
                                 .buttonStyle(.borderedProminent)
                                 .controlSize(.small)
                                 
-                                Button(copiedResetCommand ? "Copied!" : "Copy Reset Command") {
+                                Button(copiedResetCommand ? "已复制！" : "复制重置命令") {
                                     NSPasteboard.general.clearContents()
                                     NSPasteboard.general.setString(resetCommand, forType: .string)
                                     copiedResetCommand = true
@@ -236,22 +236,22 @@ public struct LiquidGlassControlPanel: View {
     
     // MARK: - Battery & Power Optimization Card
     private var batteryCard: some View {
-        HCISectionCard(title: "Battery & Performance", icon: "battery.100.bolt") {
+        HCISectionCard(title: "电池与性能", icon: "battery.100.bolt") {
             HStack(spacing: 8) {
                 Circle()
                     .fill(Color.green)
                     .frame(width: 8, height: 8)
                 
-                Text("Zero Idle Battery Impact")
+                Text("闲置时零额外耗电")
                     .font(.subheadline)
                     .fontWeight(.medium)
                     .foregroundStyle(Color.green)
                 
-                InfoButton("Battery Efficiency", content: "macTilt is 100% dormant with 0 Hz background polling during normal use. Capture is pre-armed exclusively in the millisecond you start closing your display (~95°). Metal rendering is paused until the clamshell fold begins.")
+                InfoButton("节能说明", content: "正常使用时，macTilt 完全休眠，后台轮询频率为 0 Hz。仅在开始合盖（约 95°）时准备屏幕捕获；折叠动画开始前，Metal 渲染保持暂停。")
                 
                 Spacer()
                 
-                Text(settings.isScreenCaptureDormant ? "Dormant" : "Pre-Arming")
+                Text(settings.isScreenCaptureDormant ? "休眠中" : "准备捕获")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 8)
@@ -264,15 +264,15 @@ public struct LiquidGlassControlPanel: View {
     
     // MARK: - Tilt Triggers Card
     private var tiltCard: some View {
-        HCISectionCard(title: "Tilt Trigger Thresholds", icon: "angle") {
+        HCISectionCard(title: "合盖触发角度", icon: "angle") {
             VStack(spacing: 12) {
                 // Start Angle Slider Row
                 VStack(alignment: .leading, spacing: 4) {
                     HStack {
-                        Text("Start Fold Angle")
+                        Text("开始折叠角度")
                             .font(.subheadline)
                         
-                        InfoButton("Start Angle", content: "The MacBook remains in normal usable state above this angle. Folding begins when closed below it.")
+                        InfoButton("起始角度", content: "屏幕开合角度大于此值时，MacBook 保持正常使用状态。合盖至此角度以下时，开始折叠动画。")
                         
                         Spacer()
                         
@@ -289,10 +289,10 @@ public struct LiquidGlassControlPanel: View {
                 // End Angle Slider Row
                 VStack(alignment: .leading, spacing: 4) {
                     HStack {
-                        Text("Full Fold Angle")
+                        Text("完全折叠角度")
                             .font(.subheadline)
                         
-                        InfoButton("Full Fold Angle", content: "The animation scales smoothly across the closing movement and darkens completely into black at this angle.")
+                        InfoButton("完全折叠角度", content: "动画随合盖动作平滑变化，到达此角度时，画面完全变黑。")
                         
                         Spacer()
                         
@@ -309,14 +309,14 @@ public struct LiquidGlassControlPanel: View {
     
     // MARK: - Display Source & Menu Bar Card
     private var displaySourceCard: some View {
-        HCISectionCard(title: "Display & Menu Bar", icon: "display") {
+        HCISectionCard(title: "显示与菜单栏", icon: "display") {
             VStack(spacing: 12) {
                 // Display Source Picker Row
                 HStack {
-                    Text("Screen Source")
+                    Text("画面来源")
                         .font(.subheadline)
                     
-                    InfoButton("Screen Source", content: "Choose between live desktop window freezing, current desktop wallpaper, bundled artwork, or a custom image.")
+                    InfoButton("画面来源", content: "选择实时屏幕捕获、当前桌面壁纸、内置图片或自定义图片作为动画画面。")
                     
                     Spacer()
                     
@@ -332,13 +332,13 @@ public struct LiquidGlassControlPanel: View {
                 
                 if settings.imageSourceMode == .customImage {
                     HStack {
-                        Text(settings.customImagePath.isEmpty ? "No custom photo selected" : (settings.customImagePath as NSString).lastPathComponent)
+                        Text(settings.customImagePath.isEmpty ? "尚未选择自定义图片" : (settings.customImagePath as NSString).lastPathComponent)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                             .truncationMode(.middle)
                         Spacer()
-                        Button("Choose Image...") {
+                        Button("选择图片…") {
                             selectCustomImage()
                         }
                         .buttonStyle(.bordered)
@@ -350,10 +350,10 @@ public struct LiquidGlassControlPanel: View {
                 
                 // Menu Bar Toggle Row
                 HStack {
-                    Text("Show Lid Angle in Menu Bar")
+                    Text("在菜单栏显示开合角度")
                         .font(.subheadline)
                     
-                    InfoButton("Menu Bar Display", content: "Displays the live numerical degree readout (e.g. 120°) next to the status icon.")
+                    InfoButton("菜单栏显示", content: "在状态图标旁实时显示屏幕开合角度（例如 120°）。")
                     
                     Spacer()
                     
@@ -366,15 +366,15 @@ public struct LiquidGlassControlPanel: View {
     
     // MARK: - Animation Physics Card
     private var animationPhysicsCard: some View {
-        HCISectionCard(title: "Physics & Shaders", icon: "slider.horizontal.3") {
+        HCISectionCard(title: "动画与视觉效果", icon: "slider.horizontal.3") {
             VStack(spacing: 12) {
                 // Follow Speed
                 VStack(alignment: .leading, spacing: 4) {
                     HStack {
-                        Text("Follow Responsiveness")
+                        Text("跟随灵敏度")
                             .font(.subheadline)
                         
-                        InfoButton("Follow Speed", content: "Controls the exponential smoothing physics of the display turn.")
+                        InfoButton("跟随速度", content: "控制画面折叠的平滑跟随速度。")
                         
                         Spacer()
                         
@@ -392,7 +392,7 @@ public struct LiquidGlassControlPanel: View {
                 HStack(spacing: 20) {
                     VStack(alignment: .leading, spacing: 4) {
                         HStack {
-                            Text("Blur Intensity")
+                            Text("模糊强度")
                                 .font(.subheadline)
                             Spacer()
                             Text(String(format: "%.1fx", settings.blurStrength))
@@ -405,7 +405,7 @@ public struct LiquidGlassControlPanel: View {
                     
                     VStack(alignment: .leading, spacing: 4) {
                         HStack {
-                            Text("Glass Reflection")
+                            Text("玻璃反射")
                                 .font(.subheadline)
                             Spacer()
                             Text(String(format: "%.1fx", settings.reflectionIntensity))
@@ -422,18 +422,21 @@ public struct LiquidGlassControlPanel: View {
     
     // MARK: - Lock Screen & Sleep Wake Card (Optional)
     private var lockScreenCard: some View {
-        HCISectionCard(title: "Lock Screen & Sleep Wake", icon: "lock.shield") {
+        HCISectionCard(title: "锁屏与睡眠唤醒", icon: "lock.shield") {
             VStack(alignment: .leading, spacing: 12) {
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("High Priority Display Level")
+                        Text("锁屏开盖动画")
                             .font(.subheadline)
-                        Text("Elevates overlay priority to display during wake transitions.")
+                        Text(settings.lockScreenStatus)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text("锁定期间持续跟随开合角度，可反复合盖、开盖，无时间限制。")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
                     
-                    InfoButton("Lock Screen Wake", content: "macOS isolates the password Lock Screen for security. To see the animation unfold dynamically on wake, set a 1-minute password grace period in System Settings > Lock Screen, or use Apple Watch Auto-Unlock.")
+                    InfoButton("锁屏唤醒", content: "通过系统锁屏显示空间呈现开盖动画。锁定期间使用壁纸，不显示桌面快照；动画不接收键盘和鼠标输入。此功能使用私有接口，系统更新后可能需要适配。")
                     
                     Spacer()
                     
@@ -446,33 +449,33 @@ public struct LiquidGlassControlPanel: View {
                 VStack(alignment: .leading, spacing: 6) {
                     HStack {
                         VStack(alignment: .leading, spacing: 2) {
-                            Text("Companion Screen Saver (.saver)")
+                            Text("配套屏幕保护程序（.saver）")
                                 .font(.subheadline)
-                            Text(isScreenSaverInstalled ? "Installed in ~/Library/Screen Savers/macTilt.saver" : "Renders clamshell fold directly on macOS password lock screen.")
+                            Text(isScreenSaverInstalled ? "已安装至 ~/Library/Screen Savers/macTilt.saver" : "直接在 macOS 密码锁定屏幕上呈现合盖折叠动画。")
                                 .font(.caption)
                                 .foregroundStyle(isScreenSaverInstalled ? Color.green : Color.secondary)
                         }
                         
-                        InfoButton("Lock Screen Companion", content: "Apple allows Screen Savers to render directly on the password Lock Screen. Installing this companion lets macTilt broadcast real-time lid angles to the lock screen with 0% idle battery burn.")
+                        InfoButton("锁屏配套组件", content: "Apple 允许屏幕保护程序直接在密码锁定屏幕上渲染。安装此组件后，macTilt 可向锁屏实时传递开合角度，闲置时不增加耗电。")
                         
                         Spacer()
                     }
                     
                     HStack(spacing: 8) {
-                        Button(isScreenSaverInstalled ? "Reinstall Companion" : "Install Companion (.saver)") {
+                        Button(isScreenSaverInstalled ? "重新安装组件" : "安装配套组件（.saver）") {
                             installScreenSaver()
                         }
                         .buttonStyle(.borderedProminent)
                         .controlSize(.small)
                         
                         if isScreenSaverInstalled {
-                            Button("Test Screen Saver") {
+                            Button("测试屏幕保护程序") {
                                 testScreenSaver()
                             }
                             .buttonStyle(.bordered)
                             .controlSize(.small)
                             
-                            Button("Open Settings") {
+                            Button("打开设置") {
                                 openScreenSaverSettings()
                             }
                             .buttonStyle(.bordered)
@@ -486,13 +489,13 @@ public struct LiquidGlassControlPanel: View {
     
     // MARK: - Test Preview Card
     private var testPreviewCard: some View {
-        HCISectionCard(title: "Interactive Preview", icon: "play.rectangle") {
+        HCISectionCard(title: "交互预览", icon: "play.rectangle") {
             VStack(alignment: .leading, spacing: 10) {
                 HStack {
-                    Text("Preview Animation")
+                    Text("预览动画")
                         .font(.subheadline)
                     
-                    InfoButton("Interactive Preview", content: "Scrub and inspect the fold on your screen without physically moving the lid.")
+                    InfoButton("交互预览", content: "拖动滑块即可在屏幕上预览折叠效果，无需实际开合屏幕。")
                     
                     Spacer()
                     
@@ -511,7 +514,7 @@ public struct LiquidGlassControlPanel: View {
                     
                     VStack(alignment: .leading, spacing: 4) {
                         HStack {
-                            Text("Fold Progress")
+                            Text("折叠进度")
                                 .font(.subheadline)
                             Spacer()
                             Text("\(Int(settings.testTurnValue * 100))%")
@@ -546,7 +549,7 @@ public struct LiquidGlassControlPanel: View {
     // MARK: - Bottom Footer Bar
     private var footerBar: some View {
         HStack {
-            Button("Reset to Defaults") {
+            Button("恢复默认设置") {
                 settings.startTiltAngle = 115.0
                 settings.endTiltAngle = 3.0
                 settings.followSpeed = 16.0
@@ -560,7 +563,7 @@ public struct LiquidGlassControlPanel: View {
             .buttonStyle(.bordered)
             .controlSize(.regular)
             
-            Button("Welcome Guide") {
+            Button("使用指南") {
                 MenuBarController.shared.openOnboardingWindow()
             }
             .buttonStyle(.bordered)
@@ -568,7 +571,7 @@ public struct LiquidGlassControlPanel: View {
             
             Spacer()
             
-            Button("Done") {
+            Button("完成") {
                 settings.isTestModeActive = false
                 settings.testTurnValue = 0.0
                 OverlayWindowController.shared.stopOverlay()
@@ -582,6 +585,9 @@ public struct LiquidGlassControlPanel: View {
     
     private func selectCustomImage() {
         let panel = NSOpenPanel()
+        panel.title = "选择自定义图片"
+        panel.message = "请选择用于合盖动画的图片。"
+        panel.prompt = "选择"
         panel.allowedContentTypes = [.image, .png, .jpeg]
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
@@ -602,8 +608,7 @@ public struct LiquidGlassControlPanel: View {
         try? FileManager.default.createDirectory(at: destDir, withIntermediateDirectories: true)
         let dest = destDir.appendingPathComponent("macTilt.saver")
         
-        let srcUrl = Bundle.main.url(forResource: "macTilt", withExtension: "saver")
-            ?? URL(fileURLWithPath: "/Users/ca5/Desktop/iphone-duo-macos-animation/build/macTilt.saver")
+        guard let srcUrl = Bundle.main.url(forResource: "macTilt", withExtension: "saver") else { return }
         
         if FileManager.default.fileExists(atPath: srcUrl.path) {
             try? FileManager.default.removeItem(at: dest)
@@ -711,4 +716,3 @@ private struct InfoButton: View {
         }
     }
 }
-

--- a/Sources/LiquidGlassView.swift
+++ b/Sources/LiquidGlassView.swift
@@ -442,6 +442,7 @@ public struct LiquidGlassControlPanel: View {
                     
                     Toggle("", isOn: $settings.enableLockScreenPriority)
                         .labelsHidden()
+                        .disabled(LockScreenSpace.isSIPEnabled)
                 }
                 
                 Divider()

--- a/Sources/LiquidGlassView.swift
+++ b/Sources/LiquidGlassView.swift
@@ -103,7 +103,7 @@ public struct LiquidGlassControlPanel: View {
                     .font(.title3)
                     .fontWeight(.bold)
                 
-                Text("MacBook 合盖折叠动画")
+                Text(tr("MacBook 合盖折叠动画", "Lid fold animation for MacBook"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -137,28 +137,28 @@ public struct LiquidGlassControlPanel: View {
     
     private var angleStatusText: String {
         if settings.currentLidAngle >= settings.startTiltAngle {
-            return "正常使用（已开盖）"
+            return tr("正常使用（已开盖）", "In use (lid open)")
         } else if settings.currentLidAngle <= settings.endTiltAngle {
-            return "已合盖"
+            return tr("已合盖", "Lid closed")
         } else {
             let pct = Int(settings.normalizedTurn(for: settings.currentLidAngle) * 100)
-            return "折叠中（\(pct)%）"
+            return tr("折叠中（\(pct)%）", "Folding (\(pct)%)")
         }
     }
     
     // MARK: - Screen Recording Permission Card
     private var permissionCard: some View {
-        HCISectionCard(title: "屏幕录制权限", icon: "video.badge.checkmark") {
+        HCISectionCard(title: tr("屏幕录制权限", "Screen Recording"), icon: "video.badge.checkmark") {
             HStack(spacing: 10) {
                 Image(systemName: settings.hasScreenRecordingPermission ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
                     .foregroundStyle(settings.hasScreenRecordingPermission ? Color.green : Color.orange)
                     .font(.system(size: 15))
                 
-                Text(settings.hasScreenRecordingPermission ? "已授权" : "需要授权")
+                Text(settings.hasScreenRecordingPermission ? tr("已授权", "Granted") : tr("需要授权", "Not Granted"))
                     .font(.subheadline)
                     .fontWeight(.medium)
                 
-                InfoButton("屏幕录制", content: "macTilt 需要屏幕录制权限，才能在合盖时捕获当前桌面并呈现 3D 折叠动画。所有处理均在本机完成。")
+                InfoButton(tr("屏幕录制", "Screen Recording"), content: tr("macTilt 需要屏幕录制权限，才能在合盖时捕获当前桌面并呈现 3D 折叠动画。所有处理均在本机完成。", "macTilt needs Screen Recording permission to capture your desktop when the lid closes and show it as a 3D fold. Everything is processed on this Mac."))
                 
                 Spacer()
                 
@@ -169,10 +169,10 @@ public struct LiquidGlassControlPanel: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
-                .help("重新检查权限")
+                .help(tr("重新检查权限", "Check Again"))
                 
                 if !settings.hasScreenRecordingPermission {
-                    Button("前往授权") {
+                    Button(tr("前往授权", "Grant Access")) {
                         if !ScreenCapture.shared.requestPermission() {
                             ScreenCapture.shared.openSettings()
                         }
@@ -190,24 +190,24 @@ public struct LiquidGlassControlPanel: View {
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
-                    .help("权限问题排查")
+                    .help(tr("权限问题排查", "Troubleshooting"))
                     .popover(isPresented: $showingPermissionTroubleshooting, arrowEdge: .trailing) {
                         VStack(alignment: .leading, spacing: 10) {
-                            Text("权限问题排查")
+                            Text(tr("权限问题排查", "Troubleshooting"))
                                 .font(.headline)
                             
-                            Text("如果已在系统设置中授权，请重新启动应用，让 macOS 应用新的权限。")
+                            Text(tr("如果已在系统设置中授权，请重新启动应用，让 macOS 应用新的权限。", "If you already allowed access in System Settings, relaunch the app so macOS applies the permission."))
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                             
                             HStack {
-                                Button("重新启动应用") {
+                                Button(tr("重新启动应用", "Relaunch App")) {
                                     ScreenCapture.shared.relaunchApp()
                                 }
                                 .buttonStyle(.borderedProminent)
                                 .controlSize(.small)
                                 
-                                Button(copiedResetCommand ? "已复制！" : "复制重置命令") {
+                                Button(copiedResetCommand ? tr("已复制！", "Copied!") : tr("复制重置命令", "Copy Reset Command")) {
                                     NSPasteboard.general.clearContents()
                                     NSPasteboard.general.setString(resetCommand, forType: .string)
                                     copiedResetCommand = true
@@ -236,22 +236,22 @@ public struct LiquidGlassControlPanel: View {
     
     // MARK: - Battery & Power Optimization Card
     private var batteryCard: some View {
-        HCISectionCard(title: "电池与性能", icon: "battery.100.bolt") {
+        HCISectionCard(title: tr("电池与性能", "Battery & Performance"), icon: "battery.100.bolt") {
             HStack(spacing: 8) {
                 Circle()
                     .fill(Color.green)
                     .frame(width: 8, height: 8)
                 
-                Text("闲置时零额外耗电")
+                Text(tr("闲置时零额外耗电", "No extra power use when idle"))
                     .font(.subheadline)
                     .fontWeight(.medium)
                     .foregroundStyle(Color.green)
                 
-                InfoButton("节能说明", content: "正常使用时，macTilt 完全休眠，后台轮询频率为 0 Hz。仅在开始合盖（约 95°）时准备屏幕捕获；折叠动画开始前，Metal 渲染保持暂停。")
+                InfoButton(tr("节能说明", "Power Saving"), content: tr("正常使用时，macTilt 完全休眠，后台轮询频率为 0 Hz。仅在开始合盖（约 95°）时准备屏幕捕获；折叠动画开始前，Metal 渲染保持暂停。", "During normal use, macTilt sleeps with 0 Hz background polling. It prepares a screen capture only as the lid starts to close (around 95°), and Metal rendering stays paused until the fold begins."))
                 
                 Spacer()
                 
-                Text(settings.isScreenCaptureDormant ? "休眠中" : "准备捕获")
+                Text(settings.isScreenCaptureDormant ? tr("休眠中", "Sleeping") : tr("准备捕获", "Preparing"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 8)
@@ -264,15 +264,15 @@ public struct LiquidGlassControlPanel: View {
     
     // MARK: - Tilt Triggers Card
     private var tiltCard: some View {
-        HCISectionCard(title: "合盖触发角度", icon: "angle") {
+        HCISectionCard(title: tr("合盖触发角度", "Fold Angles"), icon: "angle") {
             VStack(spacing: 12) {
                 // Start Angle Slider Row
                 VStack(alignment: .leading, spacing: 4) {
                     HStack {
-                        Text("开始折叠角度")
+                        Text(tr("开始折叠角度", "Start Angle"))
                             .font(.subheadline)
                         
-                        InfoButton("起始角度", content: "屏幕开合角度大于此值时，MacBook 保持正常使用状态。合盖至此角度以下时，画面会停留在这个角度，屏幕像玻璃一样从它前面合上，离铰链越远越暗、越模糊。")
+                        InfoButton(tr("起始角度", "Start Angle"), content: tr("屏幕开合角度大于此值时，MacBook 保持正常使用状态。合盖至此角度以下时，画面会停留在这个角度，屏幕像玻璃一样从它前面合上，离铰链越远越暗、越模糊。", "Above this angle, your MacBook works as usual. Below it, the picture stays at this angle while the screen closes in front of it like glass, growing darker and blurrier away from the hinge."))
                         
                         Spacer()
                         
@@ -289,10 +289,10 @@ public struct LiquidGlassControlPanel: View {
                 // End Angle Slider Row
                 VStack(alignment: .leading, spacing: 4) {
                     HStack {
-                        Text("完全折叠角度")
+                        Text(tr("完全折叠角度", "End Angle"))
                             .font(.subheadline)
                         
-                        InfoButton("完全折叠角度", content: "动画随合盖动作平滑变化，到达此角度时，画面完全变黑。")
+                        InfoButton(tr("完全折叠角度", "End Angle"), content: tr("动画随合盖动作平滑变化，到达此角度时，画面完全变黑。", "The animation follows the lid smoothly and is fully black at this angle."))
                         
                         Spacer()
                         
@@ -309,14 +309,14 @@ public struct LiquidGlassControlPanel: View {
     
     // MARK: - Display Source & Menu Bar Card
     private var displaySourceCard: some View {
-        HCISectionCard(title: "显示与菜单栏", icon: "display") {
+        HCISectionCard(title: tr("显示与菜单栏", "Display & Menu Bar"), icon: "display") {
             VStack(spacing: 12) {
                 // Display Source Picker Row
                 HStack {
-                    Text("画面来源")
+                    Text(tr("画面来源", "Image Source"))
                         .font(.subheadline)
                     
-                    InfoButton("画面来源", content: "选择实时屏幕捕获、当前桌面壁纸、内置图片或自定义图片作为动画画面。")
+                    InfoButton(tr("画面来源", "Image Source"), content: tr("选择实时屏幕捕获、当前桌面壁纸、内置图片或自定义图片作为动画画面。", "Use a live screen capture, the current desktop wallpaper, the bundled artwork, or a custom image for the animation."))
                     
                     Spacer()
                     
@@ -332,13 +332,13 @@ public struct LiquidGlassControlPanel: View {
                 
                 if settings.imageSourceMode == .customImage {
                     HStack {
-                        Text(settings.customImagePath.isEmpty ? "尚未选择自定义图片" : (settings.customImagePath as NSString).lastPathComponent)
+                        Text(settings.customImagePath.isEmpty ? tr("尚未选择自定义图片", "No custom image selected") : (settings.customImagePath as NSString).lastPathComponent)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                             .truncationMode(.middle)
                         Spacer()
-                        Button("选择图片…") {
+                        Button(tr("选择图片…", "Choose Image…")) {
                             selectCustomImage()
                         }
                         .buttonStyle(.bordered)
@@ -350,15 +350,34 @@ public struct LiquidGlassControlPanel: View {
                 
                 // Menu Bar Toggle Row
                 HStack {
-                    Text("在菜单栏显示开合角度")
+                    Text(tr("在菜单栏显示开合角度", "Show Lid Angle in Menu Bar"))
                         .font(.subheadline)
                     
-                    InfoButton("菜单栏显示", content: "在状态图标旁实时显示屏幕开合角度（例如 120°）。")
+                    InfoButton(tr("菜单栏显示", "Menu Bar"), content: tr("在状态图标旁实时显示屏幕开合角度（例如 120°）。", "Shows the live lid angle next to the status icon, for example 120°."))
                     
                     Spacer()
                     
                     Toggle("", isOn: $settings.showAngleInMenuBar)
                         .labelsHidden()
+                }
+
+                Divider()
+
+                // Language Row
+                HStack {
+                    Text(tr("语言", "Language"))
+                        .font(.subheadline)
+
+                    Spacer()
+
+                    Picker("", selection: $settings.language) {
+                        ForEach(AppLanguage.allCases) { language in
+                            Text(language.title).tag(language)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.segmented)
+                    .frame(width: 220)
                 }
             }
         }
@@ -366,15 +385,15 @@ public struct LiquidGlassControlPanel: View {
     
     // MARK: - Animation Physics Card
     private var animationPhysicsCard: some View {
-        HCISectionCard(title: "动画与视觉效果", icon: "slider.horizontal.3") {
+        HCISectionCard(title: tr("动画与视觉效果", "Animation & Effects"), icon: "slider.horizontal.3") {
             VStack(spacing: 12) {
                 // Follow Speed
                 VStack(alignment: .leading, spacing: 4) {
                     HStack {
-                        Text("跟随灵敏度")
+                        Text(tr("跟随灵敏度", "Follow Speed"))
                             .font(.subheadline)
                         
-                        InfoButton("跟随速度", content: "控制画面折叠的平滑跟随速度。")
+                        InfoButton(tr("跟随速度", "Follow Speed"), content: tr("画面追上屏幕实际角度的速度。数值越大越跟手，越小越顺滑，但会稍有延迟。", "How quickly the fold catches up with the lid. Higher values follow more tightly; lower values are smoother but lag slightly."))
                         
                         Spacer()
                         
@@ -392,7 +411,7 @@ public struct LiquidGlassControlPanel: View {
                 HStack(spacing: 20) {
                     VStack(alignment: .leading, spacing: 4) {
                         HStack {
-                            Text("模糊强度")
+                            Text(tr("模糊强度", "Blur"))
                                 .font(.subheadline)
                             Spacer()
                             Text(String(format: "%.1fx", settings.blurStrength))
@@ -405,7 +424,7 @@ public struct LiquidGlassControlPanel: View {
                     
                     VStack(alignment: .leading, spacing: 4) {
                         HStack {
-                            Text("玻璃反射")
+                            Text(tr("玻璃反射", "Glass Reflection"))
                                 .font(.subheadline)
                             Spacer()
                             Text(String(format: "%.1fx", settings.reflectionIntensity))
@@ -422,21 +441,21 @@ public struct LiquidGlassControlPanel: View {
     
     // MARK: - Lock Screen & Sleep Wake Card (Optional)
     private var lockScreenCard: some View {
-        HCISectionCard(title: "锁屏与睡眠唤醒", icon: "lock.shield") {
+        HCISectionCard(title: tr("锁屏与睡眠唤醒", "Lock Screen & Wake"), icon: "lock.shield") {
             VStack(alignment: .leading, spacing: 12) {
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("锁屏开盖动画")
+                        Text(tr("锁屏开盖动画", "Lock Screen Animation"))
                             .font(.subheadline)
-                        Text(settings.lockScreenStatus)
+                        Text(settings.lockScreenStatus.text)
                             .font(.caption)
                             .foregroundColor(.secondary)
-                        Text("锁定期间持续跟随开合角度，可反复合盖、开盖，无时间限制。")
+                        Text(tr("锁定期间持续跟随开合角度，可反复合盖、开盖，无时间限制。", "Follows the lid angle while locked, however often you close and open it, with no time limit."))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
                     
-                    InfoButton("锁屏唤醒", content: "通过系统锁屏显示空间呈现开盖动画。锁定期间使用壁纸，不显示桌面快照；动画不接收键盘和鼠标输入。此功能使用私有接口，系统更新后可能需要适配。")
+                    InfoButton(tr("锁屏唤醒", "Lock Screen Wake"), content: tr("通过系统锁屏显示空间呈现开盖动画。锁定期间使用壁纸，不显示桌面快照；动画不接收键盘和鼠标输入。此功能使用私有接口，需要关闭 SIP，系统更新后可能需要适配。", "Shows the lid-open animation in the system lock screen display space. While locked it uses the wallpaper instead of a desktop snapshot, and the animation never receives keyboard or mouse input. It uses private interfaces, requires SIP to be disabled, and may need updates after macOS changes."))
                     
                     Spacer()
                     
@@ -450,33 +469,33 @@ public struct LiquidGlassControlPanel: View {
                 VStack(alignment: .leading, spacing: 6) {
                     HStack {
                         VStack(alignment: .leading, spacing: 2) {
-                            Text("配套屏幕保护程序（.saver）")
+                            Text(tr("配套屏幕保护程序（.saver）", "Companion Screen Saver (.saver)"))
                                 .font(.subheadline)
-                            Text(isScreenSaverInstalled ? "已安装至 ~/Library/Screen Savers/macTilt.saver" : "直接在 macOS 密码锁定屏幕上呈现合盖折叠动画。")
+                            Text(isScreenSaverInstalled ? tr("已安装至 ~/Library/Screen Savers/macTilt.saver", "Installed at ~/Library/Screen Savers/macTilt.saver") : tr("直接在 macOS 密码锁定屏幕上呈现合盖折叠动画。", "Shows the fold animation directly on the macOS password lock screen."))
                                 .font(.caption)
                                 .foregroundStyle(isScreenSaverInstalled ? Color.green : Color.secondary)
                         }
                         
-                        InfoButton("锁屏配套组件", content: "Apple 允许屏幕保护程序直接在密码锁定屏幕上渲染。安装此组件后，macTilt 可向锁屏实时传递开合角度，闲置时不增加耗电。")
+                        InfoButton(tr("锁屏配套组件", "Lock Screen Companion"), content: tr("Apple 允许屏幕保护程序直接在密码锁定屏幕上渲染。安装此组件后，macTilt 可向锁屏实时传递开合角度，闲置时不增加耗电。", "Apple lets screen savers draw directly on the password lock screen. With this component installed, macTilt passes the lid angle to the lock screen in real time, with no extra power use when idle."))
                         
                         Spacer()
                     }
                     
                     HStack(spacing: 8) {
-                        Button(isScreenSaverInstalled ? "重新安装组件" : "安装配套组件（.saver）") {
+                        Button(isScreenSaverInstalled ? tr("重新安装组件", "Reinstall Component") : tr("安装配套组件（.saver）", "Install Companion (.saver)")) {
                             installScreenSaver()
                         }
                         .buttonStyle(.borderedProminent)
                         .controlSize(.small)
                         
                         if isScreenSaverInstalled {
-                            Button("测试屏幕保护程序") {
+                            Button(tr("测试屏幕保护程序", "Test Screen Saver")) {
                                 testScreenSaver()
                             }
                             .buttonStyle(.bordered)
                             .controlSize(.small)
                             
-                            Button("打开设置") {
+                            Button(tr("打开设置", "Open Settings")) {
                                 openScreenSaverSettings()
                             }
                             .buttonStyle(.bordered)
@@ -490,13 +509,13 @@ public struct LiquidGlassControlPanel: View {
     
     // MARK: - Test Preview Card
     private var testPreviewCard: some View {
-        HCISectionCard(title: "交互预览", icon: "play.rectangle") {
+        HCISectionCard(title: tr("交互预览", "Interactive Preview"), icon: "play.rectangle") {
             VStack(alignment: .leading, spacing: 10) {
                 HStack {
-                    Text("预览动画")
+                    Text(tr("预览动画", "Preview Animation"))
                         .font(.subheadline)
                     
-                    InfoButton("交互预览", content: "拖动滑块即可在屏幕上预览折叠效果，无需实际开合屏幕。")
+                    InfoButton(tr("交互预览", "Interactive Preview"), content: tr("拖动滑块即可在屏幕上预览折叠效果，无需实际开合屏幕。", "Drag the slider to preview the fold on screen without moving the lid."))
                     
                     Spacer()
                     
@@ -515,7 +534,7 @@ public struct LiquidGlassControlPanel: View {
                     
                     VStack(alignment: .leading, spacing: 4) {
                         HStack {
-                            Text("折叠进度")
+                            Text(tr("折叠进度", "Fold Progress"))
                                 .font(.subheadline)
                             Spacer()
                             Text("\(Int(settings.testTurnValue * 100))%")
@@ -550,7 +569,7 @@ public struct LiquidGlassControlPanel: View {
     // MARK: - Bottom Footer Bar
     private var footerBar: some View {
         HStack {
-            Button("恢复默认设置") {
+            Button(tr("恢复默认设置", "Restore Defaults")) {
                 settings.startTiltAngle = 115.0
                 settings.endTiltAngle = 3.0
                 settings.followSpeed = 16.0
@@ -564,7 +583,7 @@ public struct LiquidGlassControlPanel: View {
             .buttonStyle(.bordered)
             .controlSize(.regular)
             
-            Button("使用指南") {
+            Button(tr("使用指南", "Guide")) {
                 MenuBarController.shared.openOnboardingWindow()
             }
             .buttonStyle(.bordered)
@@ -572,7 +591,7 @@ public struct LiquidGlassControlPanel: View {
             
             Spacer()
             
-            Button("完成") {
+            Button(tr("完成", "Done")) {
                 settings.isTestModeActive = false
                 settings.testTurnValue = 0.0
                 OverlayWindowController.shared.stopOverlay()
@@ -586,9 +605,9 @@ public struct LiquidGlassControlPanel: View {
     
     private func selectCustomImage() {
         let panel = NSOpenPanel()
-        panel.title = "选择自定义图片"
-        panel.message = "请选择用于合盖动画的图片。"
-        panel.prompt = "选择"
+        panel.title = tr("选择自定义图片", "Choose a Custom Image")
+        panel.message = tr("请选择用于合盖动画的图片。", "Choose an image for the lid animation.")
+        panel.prompt = tr("选择", "Choose")
         panel.allowedContentTypes = [.image, .png, .jpeg]
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false

--- a/Sources/LiquidGlassView.swift
+++ b/Sources/LiquidGlassView.swift
@@ -272,7 +272,7 @@ public struct LiquidGlassControlPanel: View {
                         Text("开始折叠角度")
                             .font(.subheadline)
                         
-                        InfoButton("起始角度", content: "屏幕开合角度大于此值时，MacBook 保持正常使用状态。合盖至此角度以下时，开始折叠动画。")
+                        InfoButton("起始角度", content: "屏幕开合角度大于此值时，MacBook 保持正常使用状态。合盖至此角度以下时，画面会停留在这个角度，屏幕像玻璃一样从它前面合上，离铰链越远越暗、越模糊。")
                         
                         Spacer()
                         

--- a/Sources/LockScreenSpace.swift
+++ b/Sources/LockScreenSpace.swift
@@ -11,6 +11,17 @@ final class LockScreenSpace {
     private typealias Show = @convention(c) (Int32, CFArray) -> Int32
     private typealias Add = @convention(c) (Int32, Int32, CFArray, Int32) -> Int32
     private typealias CopySpaces = @convention(c) (Int32, Int32, CFArray) -> Unmanaged<CFArray>?
+    private typealias ActiveConfig = @convention(c) (UnsafeMutablePointer<UInt32>) -> Int32
+
+    /// True unless System Integrity Protection has been relaxed. The lock-screen space
+    /// needs SIP off; if the state can't be read, treat SIP as on.
+    static let isSIPEnabled: Bool = {
+        guard let handle = dlopen(nil, RTLD_NOW),
+              let symbol = dlsym(handle, "csr_get_active_config") else { return true }
+        var config: UInt32 = 0
+        return unsafeBitCast(symbol, to: ActiveConfig.self)(&config) != 0 || config == 0
+    }()
+
     private var copySpaces: CopySpaces?
     private var connection: Int32 = 0
     private var space: Int32 = 0

--- a/Sources/LockScreenSpace.swift
+++ b/Sources/LockScreenSpace.swift
@@ -36,7 +36,7 @@ final class LockScreenSpace {
               let l = dlsym(handle, "SLSSpaceSetAbsoluteLevel"),
               let v = dlsym(handle, "SLSShowSpaces"),
               let a = dlsym(handle, "SLSSpaceAddWindowsAndRemoveFromSpaces") else {
-            NSLog("[macTilt] 锁屏显示接口不可用")
+            NSLog("[macTilt] Lock screen display interface unavailable")
             return
         }
         connection = unsafeBitCast(c, to: Connection.self)()
@@ -60,7 +60,7 @@ final class LockScreenSpace {
         // rather than interpreting an undefined return register as CGError.
         let spaces = copySpaces?(connection, 7, [window.windowNumber] as CFArray)?.takeRetainedValue() as? [NSNumber] ?? []
         let success = spaces.contains { $0.int32Value == space }
-        NSLog("[macTilt] 锁屏显示空间：%@，目标 %d，窗口 %d，实际 %@", success ? "已验证归属" : "归属查询未确认", space, Int32(window.windowNumber), String(describing: spaces))
+        NSLog("[macTilt] Lock screen space: %@, target %d, window %d, actual %@", success ? "membership verified" : "membership unconfirmed", space, Int32(window.windowNumber), String(describing: spaces))
         return levelResult == 0
     }
 }

--- a/Sources/LockScreenSpace.swift
+++ b/Sources/LockScreenSpace.swift
@@ -1,0 +1,55 @@
+import AppKit
+import Darwin
+
+// SkyLight ABI and space technique based on Lakr233/SkyLightWindow (MIT).
+// See Resources/ThirdParty/SkyLightWindow-LICENSE.txt.
+final class LockScreenSpace {
+    static let shared = LockScreenSpace()
+    private typealias Connection = @convention(c) () -> Int32
+    private typealias Create = @convention(c) (Int32, Int32, Int32) -> Int32
+    private typealias SetLevel = @convention(c) (Int32, Int32, Int32) -> Int32
+    private typealias Show = @convention(c) (Int32, CFArray) -> Int32
+    private typealias Add = @convention(c) (Int32, Int32, CFArray, Int32) -> Int32
+    private typealias CopySpaces = @convention(c) (Int32, Int32, CFArray) -> Unmanaged<CFArray>?
+    private var copySpaces: CopySpaces?
+    private var connection: Int32 = 0
+    private var space: Int32 = 0
+    private var setLevel: SetLevel?
+    private var show: Show?
+    private var add: Add?
+
+    private init() {
+        guard let handle = dlopen("/System/Library/PrivateFrameworks/SkyLight.framework/Versions/A/SkyLight", RTLD_NOW),
+              let c = dlsym(handle, "SLSMainConnectionID"),
+              let s = dlsym(handle, "SLSSpaceCreate"),
+              let l = dlsym(handle, "SLSSpaceSetAbsoluteLevel"),
+              let v = dlsym(handle, "SLSShowSpaces"),
+              let a = dlsym(handle, "SLSSpaceAddWindowsAndRemoveFromSpaces") else {
+            NSLog("[macTilt] 锁屏显示接口不可用")
+            return
+        }
+        connection = unsafeBitCast(c, to: Connection.self)()
+        space = unsafeBitCast(s, to: Create.self)(connection, 1, 0)
+        guard space > 0 else { return }
+        setLevel = unsafeBitCast(l, to: SetLevel.self)
+        show = unsafeBitCast(v, to: Show.self)
+        add = unsafeBitCast(a, to: Add.self)
+        if let symbol = dlsym(handle, "SLSCopySpacesForWindows") {
+            copySpaces = unsafeBitCast(symbol, to: CopySpaces.self)
+        }
+    }
+
+    @discardableResult
+    func configure(_ window: NSWindow, enabled: Bool) -> Bool {
+        guard space > 0, let setLevel, let show, let add else { return false }
+        let levelResult = setLevel(connection, space, enabled ? 400 : 0)
+        _ = add(connection, space, [window.windowNumber] as CFArray, 7)
+        _ = show(connection, [space] as CFArray)
+        // Some SkyLight entry points are void on newer systems; verify membership,
+        // rather than interpreting an undefined return register as CGError.
+        let spaces = copySpaces?(connection, 7, [window.windowNumber] as CFArray)?.takeRetainedValue() as? [NSNumber] ?? []
+        let success = spaces.contains { $0.int32Value == space }
+        NSLog("[macTilt] 锁屏显示空间：%@，目标 %d，窗口 %d，实际 %@", success ? "已验证归属" : "归属查询未确认", space, Int32(window.windowNumber), String(describing: spaces))
+        return levelResult == 0
+    }
+}

--- a/Sources/MenuBarController.swift
+++ b/Sources/MenuBarController.swift
@@ -27,36 +27,36 @@ public final class MenuBarController: NSObject, NSWindowDelegate {
         
         let menu = NSMenu()
         
-        let header = NSMenuItem(title: "macTilt Clamshell Animation", action: nil, keyEquivalent: "")
+        let header = NSMenuItem(title: "macTilt 合盖动画", action: nil, keyEquivalent: "")
         header.isEnabled = false
         menu.addItem(header)
         
-        let angleItem = NSMenuItem(title: "Lid Sensor: Initializing...", action: nil, keyEquivalent: "")
+        let angleItem = NSMenuItem(title: "开合传感器：正在初始化…", action: nil, keyEquivalent: "")
         angleItem.isEnabled = false
         self.angleMenuItem = angleItem
         menu.addItem(angleItem)
         
         menu.addItem(NSMenuItem.separator())
         
-        let openSettings = NSMenuItem(title: "Control Panel & Settings...", action: #selector(openControlPanel), keyEquivalent: ",")
+        let openSettings = NSMenuItem(title: "控制面板与设置…", action: #selector(openControlPanel), keyEquivalent: ",")
         openSettings.target = self
         menu.addItem(openSettings)
         
-        let welcomeItem = NSMenuItem(title: "Welcome Guide & Permissions...", action: #selector(openOnboardingWindow), keyEquivalent: "")
+        let welcomeItem = NSMenuItem(title: "使用指南与权限…", action: #selector(openOnboardingWindow), keyEquivalent: "")
         welcomeItem.target = self
         menu.addItem(welcomeItem)
         
-        let testToggle = NSMenuItem(title: "Toggle Test Preview Slider", action: #selector(toggleTestMode), keyEquivalent: "t")
+        let testToggle = NSMenuItem(title: "开启／关闭动画预览", action: #selector(toggleTestMode), keyEquivalent: "t")
         testToggle.target = self
         menu.addItem(testToggle)
         
-        let captureItem = NSMenuItem(title: "Re-capture Screen Snapshot", action: #selector(recaptureScreen), keyEquivalent: "r")
+        let captureItem = NSMenuItem(title: "重新捕获屏幕快照", action: #selector(recaptureScreen), keyEquivalent: "r")
         captureItem.target = self
         menu.addItem(captureItem)
         
         menu.addItem(NSMenuItem.separator())
         
-        let quitItem = NSMenuItem(title: "Quit macTilt", action: #selector(quitApp), keyEquivalent: "q")
+        let quitItem = NSMenuItem(title: "退出 macTilt", action: #selector(quitApp), keyEquivalent: "q")
         quitItem.target = self
         menu.addItem(quitItem)
         
@@ -80,10 +80,10 @@ public final class MenuBarController: NSObject, NSWindowDelegate {
         
         if let angleItem = self.angleMenuItem {
             if isConnected {
-                let status = AppSettings.shared.isClosing ? "Closing (\(Int(angle))°)" : "Idle (\(Int(angle))°)"
-                angleItem.title = "Lid: \(status)"
+                let status = AppSettings.shared.isClosing ? "正在合盖（\(Int(angle))°）" : "空闲（\(Int(angle))°）"
+                angleItem.title = "屏幕：\(status)"
             } else {
-                angleItem.title = "Lid Sensor: Disconnected"
+                angleItem.title = "开合传感器：未连接"
             }
         }
     }
@@ -116,6 +116,7 @@ public final class MenuBarController: NSObject, NSWindowDelegate {
         win.titleVisibility = .hidden
         win.isMovableByWindowBackground = true
         win.contentViewController = NSHostingController(rootView: LiquidGlassControlPanel())
+        win.title = "macTilt 控制面板"
         win.isReleasedWhenClosed = false
         
         self.controlPanelWindow = win
@@ -148,6 +149,7 @@ public final class MenuBarController: NSObject, NSWindowDelegate {
         }
         
         win.contentViewController = NSHostingController(rootView: onboardingView)
+        win.title = "macTilt 使用指南"
         win.isReleasedWhenClosed = false
         
         self.onboardingWindow = win

--- a/Sources/MenuBarController.swift
+++ b/Sources/MenuBarController.swift
@@ -25,45 +25,49 @@ public final class MenuBarController: NSObject, NSWindowDelegate {
             button.title = ""
         }
         
+        item.menu = makeMenu()
+        self.statusItem = item
+        
+        refreshMenuBarTitle()
+    }
+
+    private func makeMenu() -> NSMenu {
         let menu = NSMenu()
         
-        let header = NSMenuItem(title: "macTilt 合盖动画", action: nil, keyEquivalent: "")
+        let header = NSMenuItem(title: tr("macTilt 合盖动画", "macTilt Lid Animation"), action: nil, keyEquivalent: "")
         header.isEnabled = false
         menu.addItem(header)
         
-        let angleItem = NSMenuItem(title: "开合传感器：正在初始化…", action: nil, keyEquivalent: "")
+        let angleItem = NSMenuItem(title: tr("开合传感器：正在初始化…", "Lid sensor: initializing…"), action: nil, keyEquivalent: "")
         angleItem.isEnabled = false
         self.angleMenuItem = angleItem
         menu.addItem(angleItem)
         
         menu.addItem(NSMenuItem.separator())
         
-        let openSettings = NSMenuItem(title: "控制面板与设置…", action: #selector(openControlPanel), keyEquivalent: ",")
+        let openSettings = NSMenuItem(title: tr("控制面板与设置…", "Control Panel & Settings…"), action: #selector(openControlPanel), keyEquivalent: ",")
         openSettings.target = self
         menu.addItem(openSettings)
         
-        let welcomeItem = NSMenuItem(title: "使用指南与权限…", action: #selector(openOnboardingWindow), keyEquivalent: "")
+        let welcomeItem = NSMenuItem(title: tr("使用指南与权限…", "Guide & Permissions…"), action: #selector(openOnboardingWindow), keyEquivalent: "")
         welcomeItem.target = self
         menu.addItem(welcomeItem)
         
-        let testToggle = NSMenuItem(title: "开启／关闭动画预览", action: #selector(toggleTestMode), keyEquivalent: "t")
+        let testToggle = NSMenuItem(title: tr("开启／关闭动画预览", "Toggle Animation Preview"), action: #selector(toggleTestMode), keyEquivalent: "t")
         testToggle.target = self
         menu.addItem(testToggle)
         
-        let captureItem = NSMenuItem(title: "重新捕获屏幕快照", action: #selector(recaptureScreen), keyEquivalent: "r")
+        let captureItem = NSMenuItem(title: tr("重新捕获屏幕快照", "Recapture Screen Snapshot"), action: #selector(recaptureScreen), keyEquivalent: "r")
         captureItem.target = self
         menu.addItem(captureItem)
         
         menu.addItem(NSMenuItem.separator())
         
-        let quitItem = NSMenuItem(title: "退出 macTilt", action: #selector(quitApp), keyEquivalent: "q")
+        let quitItem = NSMenuItem(title: tr("退出 macTilt", "Quit macTilt"), action: #selector(quitApp), keyEquivalent: "q")
         quitItem.target = self
         menu.addItem(quitItem)
         
-        item.menu = menu
-        self.statusItem = item
-        
-        refreshMenuBarTitle()
+        return menu
     }
     
     public func updateAngleDisplay(angle: Double, isConnected: Bool) {
@@ -80,10 +84,10 @@ public final class MenuBarController: NSObject, NSWindowDelegate {
         
         if let angleItem = self.angleMenuItem {
             if isConnected {
-                let status = AppSettings.shared.isClosing ? "正在合盖（\(Int(angle))°）" : "空闲（\(Int(angle))°）"
-                angleItem.title = "屏幕：\(status)"
+                let status = AppSettings.shared.isClosing ? tr("正在合盖（\(Int(angle))°）", "Closing (\(Int(angle))°)") : tr("空闲（\(Int(angle))°）", "Idle (\(Int(angle))°)")
+                angleItem.title = tr("屏幕：\(status)", "Lid: \(status)")
             } else {
-                angleItem.title = "开合传感器：未连接"
+                angleItem.title = tr("开合传感器：未连接", "Lid sensor: not connected")
             }
         }
     }
@@ -97,6 +101,17 @@ public final class MenuBarController: NSObject, NSWindowDelegate {
             }
         }
     }
+
+    /// Rebuilds the menu and window titles in the current language.
+    public func refreshLocalizedText() {
+        statusItem?.menu = makeMenu()
+        controlPanelWindow?.title = controlPanelTitle
+        onboardingWindow?.title = onboardingTitle
+        updateAngleDisplay(angle: lastAngle, isConnected: lastIsConnected)
+    }
+
+    private var controlPanelTitle: String { tr("macTilt 控制面板", "macTilt Control Panel") }
+    private var onboardingTitle: String { tr("macTilt 使用指南", "macTilt Guide") }
     
     @objc public func openControlPanel() {
         if let existing = controlPanelWindow {
@@ -116,7 +131,7 @@ public final class MenuBarController: NSObject, NSWindowDelegate {
         win.titleVisibility = .hidden
         win.isMovableByWindowBackground = true
         win.contentViewController = NSHostingController(rootView: LiquidGlassControlPanel())
-        win.title = "macTilt 控制面板"
+        win.title = controlPanelTitle
         win.isReleasedWhenClosed = false
         
         self.controlPanelWindow = win
@@ -149,7 +164,7 @@ public final class MenuBarController: NSObject, NSWindowDelegate {
         }
         
         win.contentViewController = NSHostingController(rootView: onboardingView)
-        win.title = "macTilt 使用指南"
+        win.title = onboardingTitle
         win.isReleasedWhenClosed = false
         
         self.onboardingWindow = win

--- a/Sources/MetalFoldView.swift
+++ b/Sources/MetalFoldView.swift
@@ -8,6 +8,7 @@ public struct Uniforms {
     public var cover: SIMD2<Float>
     public var aspect: Float
     public var turn: Float
+    public var sweep: Float
     public var blurStrength: Float
     public var reflectionIntensity: Float
     
@@ -15,12 +16,14 @@ public struct Uniforms {
                 cover: SIMD2<Float> = .init(1, 1),
                 aspect: Float = 1.0,
                 turn: Float = 0.0,
+                sweep: Float = 0.0,
                 blurStrength: Float = 1.0,
                 reflectionIntensity: Float = 1.0) {
         self.imageSize = imageSize
         self.cover = cover
         self.aspect = aspect
         self.turn = turn
+        self.sweep = sweep
         self.blurStrength = blurStrength
         self.reflectionIntensity = reflectionIntensity
     }
@@ -35,6 +38,9 @@ public final class MetalFoldView: MTKView, MTKViewDelegate {
     private var imageSize: SIMD2<Float> = .init(1920, 1080)
     
     public var currentTurn: Float = 0.0
+    /// Degrees between the start and end angles. The picture stays at the start angle
+    /// while the glass turns through `currentTurn * lidTravel`.
+    public var lidTravel: Float = 112.0
     public var blurStrength: Float = 0.5
     public var reflectionIntensity: Float = 0.0
     
@@ -212,6 +218,7 @@ public final class MetalFoldView: MTKView, MTKViewDelegate {
             cover: cover,
             aspect: aspect,
             turn: currentTurn,
+            sweep: currentTurn * lidTravel * .pi / 180,
             blurStrength: blurStrength,
             reflectionIntensity: reflectionIntensity
         )
@@ -221,7 +228,7 @@ public final class MetalFoldView: MTKView, MTKViewDelegate {
         encoder.setFragmentSamplerState(samplerState, index: 0)
         encoder.setFragmentBytes(&uniforms, length: MemoryLayout<Uniforms>.stride, index: 0)
         
-        encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6)
+        encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)
         encoder.endEncoding()
         
         // Keep the overlay hidden until its first fresh frame has reached the GPU.

--- a/Sources/MetalFoldView.swift
+++ b/Sources/MetalFoldView.swift
@@ -96,8 +96,7 @@ public final class MetalFoldView: MTKView, MTKViewDelegate {
         if library == nil {
             let possiblePaths = [
                 Bundle.main.bundlePath + "/Contents/Resources/FoldShaders.metal",
-                Bundle.main.bundlePath + "/FoldShaders.metal",
-                "/Users/ca5/Desktop/iphone-duo-macos-animation/Sources/FoldShaders.metal"
+                Bundle.main.bundlePath + "/FoldShaders.metal"
             ]
             for p in possiblePaths {
                 if let source = try? String(contentsOfFile: p, encoding: .utf8) {
@@ -123,8 +122,11 @@ public final class MetalFoldView: MTKView, MTKViewDelegate {
         self.pipelineState = try? dev.makeRenderPipelineState(descriptor: pipeDesc)
     }
     
-    public func updateImage(_ cgImage: CGImage) {
-        guard let dev = self.device else { return }
+    public var onNextFrameReady: (() -> Void)?
+
+    @discardableResult
+    public func updateImage(_ cgImage: CGImage) -> Bool {
+        guard let dev = self.device else { return false }
         
         let width = cgImage.width
         let height = cgImage.height
@@ -141,7 +143,7 @@ public final class MetalFoldView: MTKView, MTKViewDelegate {
         desc.mipmapLevelCount = levels
         desc.usage = [.shaderRead, .renderTarget]
         
-        guard let texture = dev.makeTexture(descriptor: desc) else { return }
+        guard let texture = dev.makeTexture(descriptor: desc) else { return false }
         
         // Render CGImage into level 0
         let colorSpace = CGColorSpaceCreateDeviceRGB()
@@ -156,7 +158,7 @@ public final class MetalFoldView: MTKView, MTKViewDelegate {
             bytesPerRow: bytesPerRow,
             space: colorSpace,
             bitmapInfo: bitmapInfo
-        ) else { return }
+        ) else { return false }
         
         context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
         if let data = context.data {
@@ -178,6 +180,7 @@ public final class MetalFoldView: MTKView, MTKViewDelegate {
         }
         
         self.currentTexture = texture
+        return true
     }
     
     // MARK: - MTKViewDelegate
@@ -221,6 +224,20 @@ public final class MetalFoldView: MTKView, MTKViewDelegate {
         encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6)
         encoder.endEncoding()
         
+        // Keep the overlay hidden until its first fresh frame has reached the GPU.
+        // A paused MTKView can otherwise expose the drawable from the lock screen.
+        if let ready = onNextFrameReady {
+            onNextFrameReady = nil
+            cb.addCompletedHandler { [weak self] buffer in
+                DispatchQueue.main.async {
+                    if buffer.status == .completed {
+                        ready()
+                    } else {
+                        self?.onNextFrameReady = ready
+                    }
+                }
+            }
+        }
         cb.present(drawable)
         cb.commit()
     }

--- a/Sources/OnboardingView.swift
+++ b/Sources/OnboardingView.swift
@@ -19,10 +19,10 @@ public struct OnboardingView: View {
                     .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
                 
                 VStack(spacing: 4) {
-                    Text("欢迎使用 macTilt")
+                    Text(tr("欢迎使用 macTilt", "Welcome to macTilt"))
                         .font(.system(size: 26, weight: .bold))
                     
-                    Text("为 MacBook 屏幕带来逼真的 3D 合盖折叠动画。")
+                    Text(tr("为 MacBook 屏幕带来逼真的 3D 合盖折叠动画。", "A lifelike 3D fold animation for your MacBook display as the lid closes."))
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
@@ -36,22 +36,22 @@ public struct OnboardingView: View {
                 FeatureRow(
                     icon: "laptopcomputer",
                     iconColor: .blue,
-                    title: "随合盖动作自然折叠",
-                    subtitle: "与 Apple 内置屏幕开合角度传感器一比一同步。合盖时，画面从上到下平滑折叠。"
+                    title: tr("随合盖动作自然折叠", "Folds With Your Lid"),
+                    subtitle: tr("与 Apple 内置屏幕开合角度传感器一比一同步。合盖时，画面停在原来的角度，屏幕像玻璃一样从它前面合上。", "Synced one-to-one with Apple’s built-in lid angle sensor. As the lid closes, the picture stays at its angle while the screen closes in front of it like glass.")
                 )
                 
                 FeatureRow(
                     icon: "battery.100.bolt",
                     iconColor: .green,
-                    title: "闲置时零额外耗电",
-                    subtitle: "正常使用时完全休眠，无后台轮询。仅在实际合盖时准备屏幕捕获。"
+                    title: tr("闲置时零额外耗电", "No Extra Power When Idle"),
+                    subtitle: tr("正常使用时完全休眠，无后台轮询。仅在实际合盖时准备屏幕捕获。", "Fully asleep during normal use, with no background polling. A screen capture is prepared only when you actually close the lid.")
                 )
                 
                 FeatureRow(
                     icon: "record.circle.fill",
                     iconColor: .orange,
-                    title: "屏幕录制权限",
-                    subtitle: "合盖时，将当前桌面定格并呈现为 3D 动画。所有处理均在本机完成，无需联网。"
+                    title: tr("屏幕录制权限", "Screen Recording Permission"),
+                    subtitle: tr("合盖时，将当前桌面定格并呈现为 3D 动画。所有处理均在本机完成，无需联网。", "When the lid closes, your current desktop is frozen and shown as a 3D animation. Everything happens on this Mac, with no network connection.")
                 )
             }
             .padding(.horizontal, 28)
@@ -64,7 +64,7 @@ public struct OnboardingView: View {
                         .fill(settings.hasScreenRecordingPermission ? Color.green : Color.orange)
                         .frame(width: 9, height: 9)
                     
-                    Text(settings.hasScreenRecordingPermission ? "已获得屏幕录制权限" : "需要屏幕录制权限")
+                    Text(settings.hasScreenRecordingPermission ? tr("已获得屏幕录制权限", "Screen Recording permission granted") : tr("需要屏幕录制权限", "Screen Recording permission required"))
                         .font(.subheadline)
                         .fontWeight(.semibold)
                     
@@ -75,7 +75,7 @@ public struct OnboardingView: View {
                             ScreenCapture.shared.requestPermission()
                             ScreenCapture.shared.openSettings()
                         }) {
-                            Text("前往授权…")
+                            Text(tr("前往授权…", "Grant Access…"))
                         }
                         .buttonStyle(.borderedProminent)
                         .controlSize(.small)
@@ -84,7 +84,7 @@ public struct OnboardingView: View {
                 
                 if !settings.hasScreenRecordingPermission {
                     HStack {
-                        Text("在系统设置中授权后，请点击“重新启动”使其生效。")
+                        Text(tr("在系统设置中授权后，请点击“重新启动”使其生效。", "After allowing access in System Settings, click Relaunch to apply it."))
                             .font(.caption)
                             .foregroundColor(.secondary)
                         
@@ -93,7 +93,7 @@ public struct OnboardingView: View {
                         Button(action: {
                             ScreenCapture.shared.relaunchApp()
                         }) {
-                            Label("重新启动", systemImage: "arrow.clockwise")
+                            Label(tr("重新启动", "Relaunch"), systemImage: "arrow.clockwise")
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.mini)
@@ -118,7 +118,7 @@ public struct OnboardingView: View {
                     settings.hasCompletedOnboarding = true
                     onDismiss?()
                 }) {
-                    Text("开始使用")
+                    Text(tr("开始使用", "Get Started"))
                         .font(.headline)
                         .frame(minWidth: 140)
                 }

--- a/Sources/OnboardingView.swift
+++ b/Sources/OnboardingView.swift
@@ -19,10 +19,10 @@ public struct OnboardingView: View {
                     .shadow(color: Color.black.opacity(0.15), radius: 8, x: 0, y: 4)
                 
                 VStack(spacing: 4) {
-                    Text("Welcome to macTilt")
+                    Text("欢迎使用 macTilt")
                         .font(.system(size: 26, weight: .bold))
                     
-                    Text("Realistic 3D clamshell folding animation for your MacBook display.")
+                    Text("为 MacBook 屏幕带来逼真的 3D 合盖折叠动画。")
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
@@ -36,22 +36,22 @@ public struct OnboardingView: View {
                 FeatureRow(
                     icon: "laptopcomputer",
                     iconColor: .blue,
-                    title: "Physical Clamshell Folding",
-                    subtitle: "Synchronized 1:1 with Apple's internal lid angle sensor. Folds seamlessly from up to down as you close the lid."
+                    title: "随合盖动作自然折叠",
+                    subtitle: "与 Apple 内置屏幕开合角度传感器一比一同步。合盖时，画面从上到下平滑折叠。"
                 )
                 
                 FeatureRow(
                     icon: "battery.100.bolt",
                     iconColor: .green,
-                    title: "Zero Idle Battery Impact",
-                    subtitle: "100% dormant during normal use with zero background polling. Captures are pre-armed strictly during physical closing motion."
+                    title: "闲置时零额外耗电",
+                    subtitle: "正常使用时完全休眠，无后台轮询。仅在实际合盖时准备屏幕捕获。"
                 )
                 
                 FeatureRow(
                     icon: "record.circle.fill",
                     iconColor: .orange,
-                    title: "Screen Recording Permission",
-                    subtitle: "Freezes your active workspace into 3D space when closing. Processed strictly on-device with no network access."
+                    title: "屏幕录制权限",
+                    subtitle: "合盖时，将当前桌面定格并呈现为 3D 动画。所有处理均在本机完成，无需联网。"
                 )
             }
             .padding(.horizontal, 28)
@@ -64,7 +64,7 @@ public struct OnboardingView: View {
                         .fill(settings.hasScreenRecordingPermission ? Color.green : Color.orange)
                         .frame(width: 9, height: 9)
                     
-                    Text(settings.hasScreenRecordingPermission ? "Screen Recording Permission Active" : "Screen Recording Permission Required")
+                    Text(settings.hasScreenRecordingPermission ? "已获得屏幕录制权限" : "需要屏幕录制权限")
                         .font(.subheadline)
                         .fontWeight(.semibold)
                     
@@ -75,7 +75,7 @@ public struct OnboardingView: View {
                             ScreenCapture.shared.requestPermission()
                             ScreenCapture.shared.openSettings()
                         }) {
-                            Text("Grant Access...")
+                            Text("前往授权…")
                         }
                         .buttonStyle(.borderedProminent)
                         .controlSize(.small)
@@ -84,7 +84,7 @@ public struct OnboardingView: View {
                 
                 if !settings.hasScreenRecordingPermission {
                     HStack {
-                        Text("After toggling access in System Settings, click Relaunch to apply.")
+                        Text("在系统设置中授权后，请点击“重新启动”使其生效。")
                             .font(.caption)
                             .foregroundColor(.secondary)
                         
@@ -93,7 +93,7 @@ public struct OnboardingView: View {
                         Button(action: {
                             ScreenCapture.shared.relaunchApp()
                         }) {
-                            Label("Relaunch", systemImage: "arrow.clockwise")
+                            Label("重新启动", systemImage: "arrow.clockwise")
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.mini)
@@ -118,7 +118,7 @@ public struct OnboardingView: View {
                     settings.hasCompletedOnboarding = true
                     onDismiss?()
                 }) {
-                    Text("Get Started")
+                    Text("开始使用")
                         .font(.headline)
                         .frame(minWidth: 140)
                 }

--- a/Sources/OverlayWindowController.swift
+++ b/Sources/OverlayWindowController.swift
@@ -197,6 +197,7 @@ public final class OverlayWindowController: NSObject {
         // While locked, follow every sensor update without an elapsed-time cutoff.
         // Returning to the open angle hides the overlay; another close can start it again.
         mv.currentTurn = Float(visibleTurn)
+        mv.lidTravel = Float(AppSettings.shared.startTiltAngle - AppSettings.shared.endTiltAngle)
         mv.blurStrength = Float(AppSettings.shared.blurStrength)
         mv.reflectionIntensity = Float(AppSettings.shared.reflectionIntensity)
         

--- a/Sources/OverlayWindowController.swift
+++ b/Sources/OverlayWindowController.swift
@@ -8,19 +8,65 @@ public final class OverlayWindowController: NSObject {
     private var metalView: MetalFoldView?
     private var isCapturing = false
     private var wasZeroTurn = true
+    private var isSleeping = false
+    private var isLocked = false
+    private var captureGeneration = 0
+    private var wakeStartedAt: Date?
+    private var lastWakeAt = Date.distantPast
+    private var lockedTextureReady = false
+    private var unlockedTextureReady = false
+    private var displayGeneration = 0
+    private var isPreparingFrame = false
+    private var wantsOverlay = false
+    private var foldCaptureStarted = false
+
+    private func refreshLockState() {
+        let session = CGSessionCopyCurrentDictionary() as? [String: Any]
+        isLocked = session?["CGSSessionScreenIsLocked"] as? Bool ?? isLocked
+    }
+
+    private func loadLockTexture() {
+        captureGeneration += 1
+        unlockedTextureReady = false
+        foldCaptureStarted = false
+        isCapturing = false
+        let image = ScreenCapture.shared.fetchWallpaperImage() ?? ScreenCapture.shared.fetchBundledDefaultImage()
+        lockedTextureReady = image != nil
+        if let image { metalView?.updateImage(image) }
+    }
     
     public override init() {
         super.init()
+        refreshLockState()
         setupWindow()
         setupSleepObservers()
         
-        // Connect intelligent hardware pre-arming
-        LidSensor.shared.onPreArmCapture = { [weak self] in
-            self?.captureScreenAsync()
-        }
+        // Capture at the start of each fold, not earlier while the desktop can change.
+        // The sensor's pre-arm hint must not replace the image during a visible fold.
     }
     
     private func setupSleepObservers() {
+        refreshLockState()
+        let distributed = DistributedNotificationCenter.default()
+        distributed.addObserver(forName: NSNotification.Name("com.apple.screenIsLocked"), object: nil, queue: .main) { [weak self] _ in
+            guard let self else { return }
+            self.isLocked = true
+            self.stopOverlay()
+            self.loadLockTexture()
+        }
+        distributed.addObserver(forName: NSNotification.Name("com.apple.screenIsUnlocked"), object: nil, queue: .main) { [weak self] _ in
+            guard let self else { return }
+            self.isLocked = false
+            self.wakeStartedAt = nil
+            self.stopOverlay()
+            // Do not capture the unlock transition: loginwindow may still be visible.
+            // The next physical fold pre-arm captures a fresh desktop instead.
+            self.captureGeneration += 1
+            self.isCapturing = false
+            self.unlockedTextureReady = false
+            self.foldCaptureStarted = false
+            self.lockedTextureReady = false
+        }
         let ws = NSWorkspace.shared.notificationCenter
         ws.addObserver(forName: NSWorkspace.screensDidSleepNotification, object: nil, queue: .main) { [weak self] _ in
             self?.handleSleep()
@@ -37,19 +83,35 @@ public final class OverlayWindowController: NSObject {
     }
     
     private func handleSleep() {
-        metalView?.isPaused = true
-        window?.alphaValue = 0.0
-        wasZeroTurn = true
+        isSleeping = true
+        wakeStartedAt = nil
+        loadLockTexture()
+        stopOverlay()
         AppSettings.shared.isScreenCaptureDormant = true
     }
     
     private func handleWake() {
+        isSleeping = false
+        refreshLockState()
+        // Workspace emits both system-wake and display-wake notifications.
+        guard Date().timeIntervalSince(lastWakeAt) > 1 else { return }
+        lastWakeAt = Date()
         wasZeroTurn = true
-        if AppSettings.shared.imageSourceMode == .liveCapture {
-            captureScreenAsync()
+        if isLocked && AppSettings.shared.enableLockScreenPriority {
+            loadLockTexture()
+            updateWindowLevel()
+            wakeStartedAt = Date()
+        } else if !isLocked {
+            // Wake and unlock notifications can arrive in either order.
+            // Defer the desktop snapshot to the next fold in both cases.
+            captureGeneration += 1
+            isCapturing = false
+            unlockedTextureReady = false
+            foldCaptureStarted = false
+            stopOverlay()
         }
     }
-    
+
     private func setupWindow() {
         guard let screen = NSScreen.main ?? NSScreen.screens.first else { return }
         
@@ -69,6 +131,9 @@ public final class OverlayWindowController: NSObject {
         }
         win.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
         win.ignoresMouseEvents = true
+        win.canBecomeVisibleWithoutLogin = AppSettings.shared.enableLockScreenPriority
+        win.hidesOnDeactivate = false
+        win.animationBehavior = .none
         win.alphaValue = 0.0
         
         let mtkView = MetalFoldView(frame: win.contentView?.bounds ?? screen.frame)
@@ -78,48 +143,96 @@ public final class OverlayWindowController: NSObject {
         
         self.window = win
         self.metalView = mtkView
-        
-        // One-time initial image load in background during app launch
-        Task {
-            if let img = await ScreenCapture.shared.fetchImage() {
-                await MainActor.run {
-                    self.metalView?.updateImage(img)
-                    SharedStateManager.shared.saveScreenCache(img)
-                    AppSettings.shared.lastCaptureDate = Date()
-                    AppSettings.shared.isScreenCaptureDormant = true
-                }
-            }
-        }
+
+        // Materialize the WindowServer window before assigning its space.
+        // It remains fully transparent and never becomes key.
+        win.orderFrontRegardless()
+        updateWindowLevel()
+        if isLocked { loadLockTexture() }
     }
     
     public func update(turn: Double, angle: Double) {
         guard let win = self.window, let mv = self.metalView else { return }
         
-        mv.currentTurn = Float(turn)
+        guard !isSleeping else { return }
+        if isLocked && (!AppSettings.shared.enableLockScreenPriority || !lockedTextureReady) {
+            stopOverlay()
+            return
+        }
+        var visibleTurn = turn
+        if let started = wakeStartedAt {
+            let elapsed = Date().timeIntervalSince(started)
+            if elapsed < 0.8 {
+                // Deep sleep may resume after the lid has already reached its open angle.
+                visibleTurn = max(turn, pow(max(0, 1 - elapsed / 0.8), 2))
+            } else {
+                wakeStartedAt = nil
+            }
+        }
+        if visibleTurn <= 0.0001 {
+            if foldCaptureStarted {
+                // Discard a capture that finishes after this fold has already ended.
+                captureGeneration += 1
+                isCapturing = false
+                unlockedTextureReady = false
+                foldCaptureStarted = false
+                AppSettings.shared.isScreenCaptureDormant = true
+            }
+            stopOverlay()
+            return
+        }
+        if !isLocked && !foldCaptureStarted {
+            // A cached texture is never proof that this fold has a fresh snapshot.
+            captureGeneration += 1
+            isCapturing = false
+            unlockedTextureReady = false
+            foldCaptureStarted = true
+            stopOverlay()
+        }
+        if !isLocked && !unlockedTextureReady {
+            stopOverlay()
+            if visibleTurn > 0.0001 { captureScreenAsync() }
+            return
+        }
+        // While locked, follow every sensor update without an elapsed-time cutoff.
+        // Returning to the open angle hides the overlay; another close can start it again.
+        mv.currentTurn = Float(visibleTurn)
         mv.blurStrength = Float(AppSettings.shared.blurStrength)
         mv.reflectionIntensity = Float(AppSettings.shared.reflectionIntensity)
         
-        // Only trigger when closing and turn > 0
-        if turn > 0.0001 {
+        // Follow both opening and closing whenever the fold progress is nonzero.
+        if visibleTurn > 0.0001 {
             if wasZeroTurn {
                 wasZeroTurn = false
-                // If pre-arm hasn't finished or was skipped, trigger emergency snapshot
-                if AppSettings.shared.imageSourceMode == .liveCapture {
-                    captureScreenAsync()
-                }
             }
             
-            mv.isPaused = false
-            win.alphaValue = 1.0
-            win.orderFrontRegardless()
+            wantsOverlay = true
+            if win.alphaValue == 0 && !isPreparingFrame {
+                isPreparingFrame = true
+                let generation = displayGeneration
+                mv.onNextFrameReady = { [weak self] in
+                    guard let self,
+                          generation == self.displayGeneration,
+                          self.wantsOverlay, !self.isSleeping else { return }
+                    self.isPreparingFrame = false
+                    self.window?.alphaValue = 1
+                    self.window?.orderFrontRegardless()
+                }
+                mv.isPaused = false
+                mv.draw()
+            } else {
+                mv.isPaused = false
+            }
         } else {
-            wasZeroTurn = true
-            win.alphaValue = 0.0
-            mv.isPaused = true
+            stopOverlay()
         }
     }
     
     public func stopOverlay() {
+        displayGeneration += 1
+        wantsOverlay = false
+        isPreparingFrame = false
+        metalView?.onNextFrameReady = nil
         wasZeroTurn = true
         window?.alphaValue = 0.0
         metalView?.isPaused = true
@@ -128,6 +241,9 @@ public final class OverlayWindowController: NSObject {
     
     public func updateWindowLevel() {
         guard let win = self.window else { return }
+        win.canBecomeVisibleWithoutLogin = AppSettings.shared.enableLockScreenPriority
+        let ready = LockScreenSpace.shared.configure(win, enabled: AppSettings.shared.enableLockScreenPriority)
+        AppSettings.shared.lockScreenStatus = ready ? "已配置锁屏接口（待实际开盖验证）" : "锁屏显示接口不可用"
         if AppSettings.shared.enableLockScreenPriority {
             win.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()) + 1)
         } else {
@@ -136,14 +252,26 @@ public final class OverlayWindowController: NSObject {
     }
     
     public func captureScreenAsync() {
+        guard !isSleeping else { return }
+        guard !isLocked else {
+            if !lockedTextureReady { loadLockTexture() }
+            return
+        }
         guard !isCapturing else { return }
+        let generation = captureGeneration
         isCapturing = true
         AppSettings.shared.isScreenCaptureDormant = false
         
         Task {
             if let image = await ScreenCapture.shared.fetchImage() {
                 await MainActor.run {
-                    self.metalView?.updateImage(image)
+                    guard generation == self.captureGeneration, !self.isLocked, !self.isSleeping else { return }
+                    guard self.metalView?.updateImage(image) == true else {
+                        self.isCapturing = false
+                        AppSettings.shared.isScreenCaptureDormant = true
+                        return
+                    }
+                    self.unlockedTextureReady = true
                     SharedStateManager.shared.saveScreenCache(image)
                     self.isCapturing = false
                     AppSettings.shared.lastCaptureDate = Date()
@@ -151,6 +279,7 @@ public final class OverlayWindowController: NSObject {
                 }
             } else {
                 await MainActor.run {
+                    guard generation == self.captureGeneration else { return }
                     self.isCapturing = false
                     AppSettings.shared.isScreenCaptureDormant = true
                 }

--- a/Sources/OverlayWindowController.swift
+++ b/Sources/OverlayWindowController.swift
@@ -244,7 +244,11 @@ public final class OverlayWindowController: NSObject {
         guard let win = self.window else { return }
         win.canBecomeVisibleWithoutLogin = AppSettings.shared.enableLockScreenPriority
         let ready = LockScreenSpace.shared.configure(win, enabled: AppSettings.shared.enableLockScreenPriority)
-        AppSettings.shared.lockScreenStatus = ready ? "已配置锁屏接口（待实际开盖验证）" : "锁屏显示接口不可用"
+        if LockScreenSpace.isSIPEnabled {
+            AppSettings.shared.lockScreenStatus = "需要先关闭系统完整性保护（SIP）"
+        } else {
+            AppSettings.shared.lockScreenStatus = ready ? "已配置锁屏接口（待实际开盖验证）" : "锁屏显示接口不可用"
+        }
         if AppSettings.shared.enableLockScreenPriority {
             win.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()) + 1)
         } else {

--- a/Sources/OverlayWindowController.swift
+++ b/Sources/OverlayWindowController.swift
@@ -245,9 +245,9 @@ public final class OverlayWindowController: NSObject {
         win.canBecomeVisibleWithoutLogin = AppSettings.shared.enableLockScreenPriority
         let ready = LockScreenSpace.shared.configure(win, enabled: AppSettings.shared.enableLockScreenPriority)
         if LockScreenSpace.isSIPEnabled {
-            AppSettings.shared.lockScreenStatus = "需要先关闭系统完整性保护（SIP）"
+            AppSettings.shared.lockScreenStatus = .needsSIPDisabled
         } else {
-            AppSettings.shared.lockScreenStatus = ready ? "已配置锁屏接口（待实际开盖验证）" : "锁屏显示接口不可用"
+            AppSettings.shared.lockScreenStatus = ready ? .configured : .unavailable
         }
         if AppSettings.shared.enableLockScreenPriority {
             win.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()) + 1)

--- a/Sources/ScreenCapture.swift
+++ b/Sources/ScreenCapture.swift
@@ -154,8 +154,7 @@ public final class ScreenCapture {
         let fallbackPaths = [
             Bundle.main.bundlePath + "/Contents/Resources/default.png",
             Bundle.main.bundlePath + "/Resources/default.png",
-            CommandLine.arguments[0].split(separator: "/").dropLast().joined(separator: "/") + "/Resources/default.png",
-            "/Users/ca5/Desktop/iphone-duo-macos-animation/Resources/default.png"
+            CommandLine.arguments[0].split(separator: "/").dropLast().joined(separator: "/") + "/Resources/default.png"
         ]
         for path in fallbackPaths {
             if let img = NSImage(contentsOfFile: path),

--- a/Sources/ScreenSaver/MacTiltScreenSaverView.swift
+++ b/Sources/ScreenSaver/MacTiltScreenSaverView.swift
@@ -81,6 +81,9 @@ public final class MacTiltScreenSaverView: ScreenSaverView {
         }
         
         targetTurn = Double(state.turn)
+        if state.lidTravel > 0 && state.lidTravel <= 180 {
+            metalView?.lidTravel = state.lidTravel
+        }
         
         // BATTERY EFFICIENCY ENGINE:
         // When lid is stationary or fully open/closed, sleep GPU completely!

--- a/Sources/SharedStateManager.swift
+++ b/Sources/SharedStateManager.swift
@@ -12,16 +12,25 @@ public final class SharedStateManager {
         public var magic: UInt32 = 0x4D544C54 // "MTLT"
         public var angle: Float
         public var turn: Float
+        /// Degrees between the start and end angles. Older builds left this slot as padding.
+        public var lidTravel: Float
         public var timestamp: Double
     }
     
     private init() {}
     
-    /// Broadcast current physical angle and turn progress to lock screen companion
-    public func broadcast(angle: Double, turn: Double) {
+    private var lastBroadcast: (angle: Float, turn: Float, lidTravel: Float)?
+    
+    /// Broadcast current physical angle, turn progress and lid travel to lock screen companion
+    public func broadcast(angle: Double, turn: Double, lidTravel: Double) {
+        let values = (angle: Float(angle), turn: Float(turn), lidTravel: Float(lidTravel))
+        // The sensor ticks at 60 Hz; skip rewriting the file while nothing changes.
+        if let last = lastBroadcast, last == values { return }
+        lastBroadcast = values
         var data = StateData(
-            angle: Float(angle),
-            turn: Float(turn),
+            angle: values.angle,
+            turn: values.turn,
+            lidTravel: values.lidTravel,
             timestamp: CACurrentMediaTime()
         )
         withUnsafeBytes(of: &data) { rawPtr in

--- a/build.sh
+++ b/build.sh
@@ -8,29 +8,17 @@ INFO_PLIST="$DIR/Info.plist"
 
 echo "=== macTilt macOS Build & Install ==="
 
-# 1. Increment Build Number and Version Number
-if [ -f "$INFO_PLIST" ]; then
-    CURRENT_BUILD=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$INFO_PLIST" 2>/dev/null || echo "0")
-    NEW_BUILD=$((CURRENT_BUILD + 1))
-    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $NEW_BUILD" "$INFO_PLIST"
-    
-    CURRENT_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$INFO_PLIST" 2>/dev/null || echo "1.0.0")
-    # Split version and increment patch number (e.g., 1.0.0 -> 1.0.1)
-    MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
-    MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
-    PATCH=$(echo "$CURRENT_VERSION" | cut -d. -f3)
-    if [ -z "$PATCH" ]; then PATCH=0; fi
-    NEW_PATCH=$((PATCH + 1))
-    NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
-    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $NEW_VERSION" "$INFO_PLIST"
-    
-    echo "▶ Updated Version: $CURRENT_VERSION -> $NEW_VERSION"
-    echo "▶ Updated Build Number: $CURRENT_BUILD -> $NEW_BUILD"
-else
-    echo "Warning: Info.plist not found!"
-    NEW_VERSION="1.0.0"
-    NEW_BUILD="1"
-fi
+# Build metadata belongs in the generated bundle, never in the source plist.
+# Optional overrides: APP_VERSION=1.2.3 BUILD_NUMBER=42 SIGNING_IDENTITY=<SHA-1>
+INSTALL_APP=true
+case "${1:-}" in
+    "") ;;
+    --no-install) INSTALL_APP=false ;;
+    *) echo "Usage: $0 [--no-install]" >&2; exit 2 ;;
+esac
+NEW_VERSION="${APP_VERSION:-$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST")}"
+NEW_BUILD="${BUILD_NUMBER:-$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST")}"
+SIGNING_IDENTITY="${SIGNING_IDENTITY:--}"
 
 # 2. Prepare Build Directory
 BUILD_DIR="$DIR/build"
@@ -77,6 +65,10 @@ rm -f "$BUILD_DIR/macTilt_arm64" "$BUILD_DIR/macTilt_x86_64"
 
 # 5. Copy Resources & Plist
 cp "$INFO_PLIST" "$CONTENTS_DIR/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $NEW_VERSION" "$CONTENTS_DIR/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $NEW_BUILD" "$CONTENTS_DIR/Info.plist"
+
+cp -R "$DIR/Resources/ThirdParty" "$RESOURCES_DIR/ThirdParty"
 
 # Generate or copy AppIcon
 if [ ! -f "$DIR/Resources/AppIcon.icns" ] && [ -f "$DIR/Resources/AppIcon.png" ]; then
@@ -105,8 +97,6 @@ fi
 
 if [ -d "$DIR/Resources/Untitled.icon" ]; then
     cp -R "$DIR/Resources/Untitled.icon" "$RESOURCES_DIR/Untitled.icon"
-elif [ -d "/Users/ca5/Desktop/Untitled.icon" ]; then
-    cp -R "/Users/ca5/Desktop/Untitled.icon" "$RESOURCES_DIR/Untitled.icon"
 fi
 
 if [ -f "$DIR/Resources/default.png" ]; then
@@ -151,14 +141,9 @@ fi
 
 # 7. Codesign App Bundle and Screen Saver
 echo "▶ Codesigning Application Bundle & Screen Saver..."
-SIGNING_IDENTITY=$(security find-identity -v -p codesigning 2>/dev/null | grep "Apple Development" | head -n 1 | awk -F '"' '{print $2}')
-if [ -z "$SIGNING_IDENTITY" ]; then
-    SIGNING_IDENTITY="-"
-fi
-echo "▶ Using Signing Identity: $SIGNING_IDENTITY"
-if [ "$SIGNING_IDENTITY" != "-" ]; then
-    codesign --force --deep --sign "$SIGNING_IDENTITY" "$SAVER_BUNDLE"
-fi
+# Explicit identity overrides avoid ambiguous duplicate certificate names.
+# Default ad-hoc signing works without a developer account.
+codesign --force --deep --sign "$SIGNING_IDENTITY" "$SAVER_BUNDLE"
 
 # Copy signed Screen Saver into app resources
 cp -R "$SAVER_BUNDLE" "$RESOURCES_DIR/macTilt.saver"
@@ -181,7 +166,12 @@ if [ "$SIGNING_IDENTITY" != "-" ]; then
 fi
 echo "✔ DMG created and signed: $DMG_OUTPUT"
 
-# 8. Install to /Applications
+if [ "$INSTALL_APP" = false ]; then
+    echo "✔ Build complete: $APP_BUNDLE"
+    exit 0
+fi
+
+# 9. Install to /Applications
 INSTALL_TARGET="/Applications/macTilt.app"
 echo "▶ Installing to $INSTALL_TARGET..."
 


### PR DESCRIPTION
## Summary

This brings the fork's work upstream:

- **Fold animation** (d2c62e5): the display now closes like glass in front of a picture frozen at the start angle. Each pixel follows a fixed front-view ray back to that picture (as in the iPhone Duo fold), using the real lid travel between the start and end angles. Frost and darkening grow with the depth between glass and picture, so the top goes dark first, and the display is fully black at the end angle. Edges fade softly with rounded top corners, hidden areas show a dim glow of scattered light, and the frost is averaged in linear light with a vibrancy boost on smoked glass.
- **Performance**: 12 mip-prefiltered taps instead of 33, plus early exits for hidden areas. An offscreen benchmark at 2560×1664 measures about 1.2–1.3 ms per frame, down from roughly 6–10 ms. The screen saver's shared state file is only rewritten when a value changes, instead of 60 times a second.
- **Lock screen animation and SIP** (d3c6082): the option is unchecked and greyed out while System Integrity Protection is enabled, and its status explains why. The saved choice returns once SIP is off.
- **English/Chinese interface** (ccf7c70): a language picker (System, 中文, English) in the control panel. Panels, the menu bar menu and window titles switch live.
- **README** (dd76dd4): fully in English, with notes on SIP, the language switch, and how signing affects the Screen Recording permission.
- **Earlier fork commit** (de038c8): Chinese localization, the lock screen display through a SkyLight space, fresher desktop snapshots, and `build.sh` changes (ad-hoc signing by default, `SIGNING_IDENTITY`, `--no-install`).

## Testing

- Rendered the shader offscreen at lid angles from 115° to 20° and compared the frames, including full-resolution crops of edges and corners.
- `./build.sh --no-install` builds the app, screen saver and DMG; the installed app launches and runs without crashes.
- Screen Recording permission keeps working across rebuilds when the app is signed with a stable certificate.
- SIP detection was checked on a Mac with SIP disabled; the SIP-enabled path has not been run on real hardware.
- The English interface builds and launches, but has not been reviewed screen by screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
